### PR TITLE
fix: Correct map scaling and layout on lore page

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -70,7 +70,7 @@
         <div id="map-view" class="tab-content">
             <div class="map-container">
                 <img src="assets/zemuria-map.webp" alt="Map of Zemuria" class="map-image">
-                <svg id="map-overlay" class="map-overlay-svg" viewBox="0 0 2800 1744"></svg>
+                <svg id="map-overlay" class="map-overlay-svg" viewBox="0 0 117.2 73"></svg>
             </div>
         </div>
     </main>

--- a/style.css
+++ b/style.css
@@ -990,7 +990,7 @@ main {
 .map-container {
     position: relative;
     width: 100%;
-    max-width: 1000px; /* Adjust as needed */
+    max-width: 100%; /* Adjust as needed */
     margin: 2rem auto;
     border: 2px solid var(--accent-gold);
     box-shadow: 0 0 15px rgba(233, 213, 161, 0.3);


### PR DESCRIPTION
- Updated the SVG viewBox in lore.html to match the coordinate system of the path data, correcting the overlay's scale.
- Changed the .map-container max-width in style.css to 100% to ensure the map is responsive and scales with the container.