### PR TITLE
feat: Add feather effect to map regions

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -70,7 +70,13 @@
         <div id="map-view" class="tab-content">
             <div class="map-container">
                 <img src="assets/zemuria-map.webp" alt="Map of Zemuria" class="map-image">
-                <svg id="map-overlay" class="map-overlay-svg" viewBox="0 0 117.2 73"></svg>
+                <svg id="map-overlay" class="map-overlay-svg" viewBox="0 0 117.2 73">
+                    <defs>
+                        <filter id="feather">
+                            <feGaussianBlur stdDeviation="0.5" />
+                        </filter>
+                    </defs>
+                </svg>
             </div>
         </div>
     </main>

--- a/style.css
+++ b/style.css
@@ -1016,6 +1016,7 @@ main {
     stroke-width: 0.5;
     transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out;
     cursor: pointer;
+    filter: url(#feather);
 }
 
 .region-path:hover {


### PR DESCRIPTION
Adds a feathering effect to the interactive map regions to soften their edges and improve the visual quality.

- Defines an SVG filter with a `feGaussianBlur` primitive in `lore.html`.
- Applies this filter to the `.region-path` class in `style.css`.