### PR TITLE
feat: Display all region information in map infobox

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -545,9 +545,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const infoboxTitle = document.getElementById('infobox-title');
         const infoboxDescription = document.getElementById('infobox-description');
         const infoboxArt = document.getElementById('infobox-art');
+        const infoboxEmblem = document.getElementById('infobox-emblem');
+        const infoboxDetails = document.getElementById('infobox-details');
         const closeButton = infobox.querySelector('.close-btn');
 
-        if (!mapOverlay || !infobox) {
+        if (!mapOverlay || !infobox || !infoboxEmblem || !infoboxDetails) {
             console.error("Map overlay SVG or infobox element not found!");
             return;
         }
@@ -592,7 +594,28 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (region) {
                         // Populate infobox
                         infoboxTitle.textContent = region.name;
-                        // infoboxDescription.textContent = region.description;
+                        infoboxDescription.textContent = region.description;
+
+                        // Set emblem
+                        if (region.emblemAsset) {
+                            infoboxEmblem.src = `assets/logo/${region.emblemAsset}`;
+                            infoboxEmblem.style.display = 'inline';
+                        } else {
+                            infoboxEmblem.style.display = 'none';
+                        }
+
+                        // Populate details
+                        infoboxDetails.innerHTML = ''; // Clear previous details
+                        if (region.government) {
+                            const p = document.createElement('p');
+                            p.innerHTML = `<strong>Government:</strong> ${region.government}`;
+                            infoboxDetails.appendChild(p);
+                        }
+                        if (region.capital) {
+                            const p = document.createElement('p');
+                            p.innerHTML = `<strong>Capital:</strong> ${region.capital}`;
+                            infoboxDetails.appendChild(p);
+                        }
 
                         // Populate game art
                         infoboxArt.innerHTML = ''; // Clear previous art

--- a/lore.html
+++ b/lore.html
@@ -95,9 +95,17 @@
     <!-- Infobox for the interactive map -->
     <div id="map-infobox" style="display: none;">
         <button class="close-btn">&times;</button>
-        <h2 id="infobox-title"></h2>
+        <div class="infobox-header">
+            <img id="infobox-emblem" src="" alt="Region Emblem">
+            <h2 id="infobox-title"></h2>
+        </div>
+        <div class="infobox-content">
+            <div id="infobox-details">
+                <!-- Details like government/capital will be populated here -->
+            </div>
+            <p id="infobox-description"></p>
+        </div>
         <div id="infobox-art"></div>
-        <p id="infobox-description"></p>
     </div>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -1087,18 +1087,58 @@ main {
 #map-infobox h2 {
     font-family: 'Playfair Display', serif;
     color: var(--accent-gold);
-    margin-top: 0;
-    margin-bottom: 0.75rem;
+    margin: 0;
     font-size: var(--font-size-xl);
-    text-align: center;
-    flex-shrink: 0; /* Prevent title from shrinking */
+    text-align: left;
 }
 
 #map-infobox p {
     font-size: var(--font-size-sm);
     line-height: var(--line-height-relaxed);
-    margin-bottom: 0; /* Removed margin */
+    margin: 0;
     text-align: justify;
+}
+
+.infobox-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid rgba(233, 213, 161, 0.2);
+}
+
+#infobox-emblem {
+    height: 50px;
+    width: 50px;
+    min-width: 50px; /* Prevent shrinking */
+    object-fit: contain;
+    flex-shrink: 0;
+}
+
+.infobox-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1rem; /* Increased bottom margin */
+}
+
+#infobox-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: var(--font-size-sm);
+}
+
+#infobox-details p {
+    margin: 0;
+    line-height: var(--line-height-normal);
+    text-align: left;
+}
+
+#infobox-details strong {
+    color: var(--accent-gold);
+    font-weight: 700;
 }
 
 #infobox-art {


### PR DESCRIPTION
This commit enhances the map infobox on the lore page to display all available information from the regions.json file.

- Updates `lore.html` with a more structured layout for the infobox, including elements for the region's emblem, government, capital, and description.
- Modifies `lore-script.js` to fetch and populate this new data into the corresponding elements when a user clicks on a map region.
- Adds styles to `style.css` to ensure the new information is presented neatly and is consistent with the existing design.