### PR TITLE
feat: Add visual effect to map regions

### DIFF
--- a/style.css
+++ b/style.css
@@ -1027,15 +1027,19 @@ main {
 }
 
 .region-path {
-    fill: transparent;
-    stroke: transparent; /* No border by default */
-    stroke-width: 0.5;
-    transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out;
+    fill: rgba(255, 255, 255, 0.1);
+    stroke: rgba(255, 255, 255, 0.5);
+    stroke-width: 1.5;
+    filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.5));
+    transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out, stroke-width 0.2s ease-in-out, filter 0.2s ease-in-out;
     cursor: pointer;
 }
 
 .region-path:hover {
-    fill: var(--region-highlight-color); /* Use the CSS variable for highlighting */
+    fill: var(--region-highlight-color);
+    stroke: white;
+    stroke-width: 2.5;
+    filter: drop-shadow(0 0 8px var(--region-highlight-color));
 }
 
 /* --- Map Infobox Styles --- */


### PR DESCRIPTION
The outlined regions on the interactive map were previously transparent by default, only becoming visible on hover. This made it unclear that they were clickable elements.

This change adds default styling to the map regions to make them always visible and enhances the hover effect to improve interactivity.