### PR TITLE
I've implemented a dimming mask effect for the interactive map on the…

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -588,6 +588,12 @@ document.addEventListener('DOMContentLoaded', () => {
             regionsData = regions;
             gamesData = games;
 
+            const maskGroup = mapOverlay.querySelector('#regions-mask g');
+            if (!maskGroup) {
+                console.error("SVG mask group for regions not found!");
+                return;
+            }
+
             const gamesById = gamesData.reduce((acc, game) => {
                 acc[game.id] = game;
                 return acc;
@@ -607,6 +613,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 mapOverlay.appendChild(path);
+
+                // Create the second, identical path for the mask cutout
+                const maskPath = document.createElementNS(svgNS, 'path');
+                maskPath.setAttribute('d', region.svgPathData);
+                maskPath.setAttribute('fill', 'black');
+                maskGroup.appendChild(maskPath);
             });
 
             mapOverlay.addEventListener('click', (e) => {

--- a/lore.html
+++ b/lore.html
@@ -71,7 +71,14 @@
             <div class="full-width-section">
                 <div class="map-container">
                     <img src="assets/zemuria-map.webp" alt="Map of Zemuria" class="map-image">
+                    <div class="map-dim-overlay"></div>
                     <svg id="map-overlay" class="map-overlay-svg" viewBox="0 0 2800 1744">
+                        <defs>
+                            <mask id="regions-mask">
+                                <rect x="0" y="0" width="2800" height="1744" fill="white"></rect>
+                                <g></g>
+                            </mask>
+                        </defs>
                         <filter id="feather-effect" x="-50%" y="-50%" width="200%" height="200%">
                             <feMorphology operator="dilate" radius="10" in="SourceAlpha" result="dilated"/>
                             <feGaussianBlur in="dilated" stdDeviation="15" result="blurred"/>

--- a/style.css
+++ b/style.css
@@ -1018,6 +1018,24 @@ main {
     height: auto;
 }
 
+.map-dim-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    opacity: 0;
+    pointer-events: none;
+    mask: url(#regions-mask);
+    -webkit-mask: url(#regions-mask);
+    transition: opacity 0.3s ease-in-out;
+}
+
+.map-container:hover .map-dim-overlay {
+    opacity: 1;
+}
+
 .map-overlay-svg {
     position: absolute;
     top: 0;


### PR DESCRIPTION
… lore page. Now, when you hover over the map container, non-interactive areas will be dimmed with a semi-transparent overlay, leaving the selectable regions clearly visible.

Here's a summary of the changes:
- Added a `map-dim-overlay` div and an SVG mask definition to `lore.html`.
- Implemented CSS to style the overlay, apply the mask, and create a fade-in effect on hover.
- Updated `lore-script.js` to dynamically generate paths for both the interactive regions and the corresponding mask cutouts.