### PR TITLE
feat: Add colored outlines to map regions

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -610,6 +610,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (region.baseColor) {
                     const highlightColor = hexToRgba(region.baseColor, 0.5); // 50% transparency
                     path.style.setProperty('--region-highlight-color', highlightColor);
+                    path.style.stroke = region.baseColor;
                 }
 
                 mapOverlay.appendChild(path);

--- a/lore.html
+++ b/lore.html
@@ -71,7 +71,6 @@
             <div class="full-width-section">
                 <div class="map-container">
                     <img src="assets/zemuria-map.webp" alt="Map of Zemuria" class="map-image">
-                    <div class="map-dim-overlay"></div>
                     <svg id="map-overlay" class="map-overlay-svg" viewBox="0 0 2800 1744">
                         <defs>
                             <mask id="regions-mask">

--- a/style.css
+++ b/style.css
@@ -1008,17 +1008,19 @@ main {
     width: 100%;
     max-width: 100%; /* Adjust as needed */
     margin: 2rem auto;
-    border: 2px solid var(--accent-gold);
-    box-shadow: 0 0 15px rgba(233, 213, 161, 0.3);
+    /* border and box-shadow moved to .map-image to fix overlay alignment */
 }
 
 .map-image {
     display: block;
     width: 100%;
     height: auto;
+    border: 2px solid var(--accent-gold);
+    box-shadow: 0 0 15px rgba(233, 213, 161, 0.3);
 }
 
-.map-dim-overlay {
+.map-container::before {
+    content: '';
     position: absolute;
     top: 0;
     left: 0;
@@ -1030,9 +1032,10 @@ main {
     mask: url(#regions-mask);
     -webkit-mask: url(#regions-mask);
     transition: opacity 0.3s ease-in-out;
+    z-index: 1;
 }
 
-.map-container:hover .map-dim-overlay {
+.map-container:hover::before {
     opacity: 1;
 }
 
@@ -1042,12 +1045,13 @@ main {
     left: 0;
     width: 100%;
     height: 100%;
+    z-index: 2; /* Ensure SVG is above the new pseudo-element overlay */
 }
 
 .region-path {
     fill: transparent;
     stroke: transparent; /* No border by default */
-    stroke-width: 0.5;
+    stroke-width: 3;
     transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out;
     cursor: pointer;
 }


### PR DESCRIPTION
This commit adds colored outlines to the interactive map regions to make them more distinct and clearly selectable. The outline color is based on the region's `baseColor` defined in the data source.

- The `stroke-width` of region paths has been increased for better visibility.
- `lore-script.js` now dynamically assigns the `stroke` color to each region's path.

Additionally, this commit includes attempts to resolve a visual alignment issue with the dimming overlay. The overlay was refactored to use a CSS pseudo-element, and container borders were adjusted. Despite these efforts, the alignment problem persists and may require further investigation with live browser debugging tools.