### PR TITLE
feat: Add complete highlight effect to map regions

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -608,9 +608,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 // Set the highlight color as a CSS variable from the region's base color
                 if (region.baseColor) {
-                    const highlightColor = hexToRgba(region.baseColor, 0.5); // 50% transparency
+                    const highlightColor = hexToRgba(region.baseColor, 0.7); // 70% transparency
                     path.style.setProperty('--region-highlight-color', highlightColor);
-                    path.style.stroke = region.baseColor;
                 }
 
                 mapOverlay.appendChild(path);

--- a/style.css
+++ b/style.css
@@ -1047,6 +1047,8 @@ main {
 
 .region-path:hover {
     fill: var(--region-highlight-color); /* Use the CSS variable for highlighting */
+    stroke: var(--accent-gold);
+    stroke-width: 4;
 }
 
 /* --- Map Infobox Styles --- */


### PR DESCRIPTION
This commit implements a "complete highlight" effect for the interactive map regions to improve visual feedback on hover.

The changes include:
- Increasing the fill brightness of the hovered region by changing the alpha transparency from 0.5 to 0.7 in `lore-script.js`.
- Adding a 4-unit wide, contrasting gold stroke to the hovered region in `style.css`.
- Removing a redundant default stroke that was being applied via JavaScript, ensuring that styling is handled consistently in the CSS.