### PR TITLE
fix(css): Apply border-box sizing to map container

### DIFF
--- a/style.css
+++ b/style.css
@@ -1011,6 +1011,7 @@ main {
     margin: 2rem auto;
     border: 2px solid var(--accent-gold);
     box-shadow: 0 0 15px rgba(233, 213, 161, 0.3);
+    box-sizing: border-box;
 }
 
 .map-image {


### PR DESCRIPTION
The map container has a width of 100% and a 2px border. With the default `content-box` sizing, the border was added to the width, causing the element to be `100% + 4px` wide and creating a horizontal scrollbar.

By setting `box-sizing: border-box`, the border is now included within the element's total width, resolving the overflow issue.