### PR TITLE
Fix: Adjust Lore page padding and make tabs sticky

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -20,12 +20,11 @@
             <a href="games.html">Releases</a>
             <a href="lore.html" class="active">Lore</a>
         </nav>
+        <nav class="arc-navigation lore-tabs">
+            <a href="#" class="tab-link active" data-tab="timeline-view">Timeline</a>
+            <a href="#" class="tab-link" data-tab="map-view">Map</a>
+        </nav>
     </header>
-
-    <nav class="arc-navigation lore-tabs">
-        <a href="#" class="tab-link active" data-tab="timeline-view">Timeline</a>
-        <a href="#" class="tab-link" data-tab="map-view">Map</a>
-    </nav>
 
     <main>
         <div id="timeline-view" class="tab-content active">

--- a/style.css
+++ b/style.css
@@ -216,9 +216,9 @@ footer a:hover {
     /* The .arc-navigation class provides the base style. */
     /* These rules adjust it for the Lore page context. */
     border-top: none; /* The header's bottom border serves as the top line */
-    border-bottom: 1px solid rgba(233, 213, 161, 0.15); /* Add a bottom border to separate from main content */
     padding-top: 0.4rem;
     padding-bottom: 0.4rem;
+    border-bottom: none;
 }
 
 /* Tab Content Styling */
@@ -255,7 +255,7 @@ footer a:hover {
 
 /* --- Main Timeline Layout --- */
 main {
-    padding: 2rem 1rem;
+    padding: 1rem;
     max-width: 1300px;
     margin: 0 auto;
     min-width: 600px; /* Ensure enough space for slider arrows + content */


### PR DESCRIPTION
- Reduced the top padding on the `main` element to create a more natural gap between the header and the content.
- Moved the 'Timeline' and 'Map' navigation tabs into the main `<header>` element, making them sticky.
- Removed the bottom border from the tabs to prevent a double border with the header.