### PR TITLE
Fix horizontal scrollbar on game releases page

### DIFF
--- a/style.css
+++ b/style.css
@@ -385,7 +385,7 @@ main {
 }
 
 .game-entry-slider {
-    overflow-x: visible; /* This allows box-shadows to appear */
+    overflow-x: hidden; /* Hides horizontal overflow of slider items, may clip side shadows */
     overflow-y: visible; /* This allows the vertical box-shadow to be displayed */
     position: relative; /* Optional: if it needs to be a positioning context for something else inside, though not strictly necessary for current setup */
     /* width: 100%; Ensure it takes the space of a normal game-entry.


### PR DESCRIPTION
The slider for game variants on the releases page was causing a horizontal scrollbar to appear on the first slide. This was due to the `.game-entry-slider` class having `overflow-x: visible`, which allowed the second slide to overflow the page layout.

This change sets `overflow-x: hidden` on the `.game-entry-slider` to prevent the overflow and remove the unwanted scrollbar. The accompanying comment has been updated to reflect this change.