### PR TITLE
Fix horizontal scrollbar on game releases page

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,6 +32,7 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    overflow-x: hidden; /* Prevent horizontal scrollbars from slider overflow */
 }
 
 /* Apply background only to the home page's body */
@@ -385,7 +386,7 @@ main {
 }
 
 .game-entry-slider {
-    overflow-x: hidden; /* Hides horizontal overflow of slider items, may clip side shadows */
+    overflow-x: visible; /* This allows box-shadows to appear */
     overflow-y: visible; /* This allows the vertical box-shadow to be displayed */
     position: relative; /* Optional: if it needs to be a positioning context for something else inside, though not strictly necessary for current setup */
     /* width: 100%; Ensure it takes the space of a normal game-entry.


### PR DESCRIPTION
A horizontal scrollbar was appearing on the releases page due to a slider component overflowing the page width. While the slider's internal overflow is intentional to allow for box-shadows, it should not cause a page-level scrollbar.

To resolve this, I added `overflow-x: hidden` to the `body` element as a global rule. This prevents the viewport from ever scrolling horizontally and resolves the issue without affecting the slider's aesthetic or functionality.