### PR TITLE
Refactors the map's infobox into a two-sided, flippable card that can…

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -110,12 +110,31 @@
 
     <!-- Infobox for the interactive map -->
     <div id="map-infobox" style="display: none;">
-        <button class="close-btn">&times;</button>
-        <div class="infobox-header">
-            <!-- This will be populated by JS -->
-        </div>
-        <div class="infobox-games">
-            <!-- Game art will be populated by JS -->
+        <div class="infobox-flipper">
+            <div class="infobox-front">
+                <button class="close-btn">&times;</button>
+                <div class="infobox-header">
+                    <!-- Populated by JS -->
+                </div>
+                <div class="infobox-games">
+                    <!-- Game art populated by JS -->
+                </div>
+                <div class="infobox-footer">
+                    <button class="toggle-lore-btn">View Lore</button>
+                </div>
+            </div>
+            <div class="infobox-back">
+                <button class="close-btn">&times;</button>
+                <div class="infobox-header">
+                    <!-- Populated by JS -->
+                </div>
+                <div class="infobox-lore-details">
+                    <!-- Lore details populated by JS -->
+                </div>
+                <div class="infobox-footer">
+                    <button class="toggle-lore-btn">Show Game Art</button>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -682,6 +682,40 @@ body.home-page::before {
 #map-infobox {
     position: fixed;
     z-index: 2000;
+    width: max-content;
+    max-width: 90vw;
+    transform-origin: top left;
+    perspective: 1500px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    /* Remove background and padding from the container */
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+#map-infobox.active {
+    opacity: 1;
+    pointer-events: auto;
+}
+.infobox-flipper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transition: transform 0.8s;
+    transform-style: preserve-3d;
+}
+#map-infobox.is-flipped .infobox-flipper {
+    transform: rotateY(180deg);
+}
+.infobox-front, .infobox-back {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    /* Common styling for both faces */
+    display: flex;
+    flex-direction: column;
     background: rgba(20, 20, 30, 0.85);
     backdrop-filter: blur(10px);
     border: 1px solid var(--accent-gold);
@@ -689,18 +723,13 @@ body.home-page::before {
     box-shadow: 0 8px 30px rgba(0, 0, 0, 0.6);
     color: var(--text-primary);
     padding: 0.75rem 1.5rem;
-    transform-origin: top left;
-    width: max-content;
-    max-width: 90vw;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    pointer-events: none;
-    display: flex;
-    flex-direction: column;
+    box-sizing: border-box;
 }
-#map-infobox.active {
-    opacity: 1;
-    pointer-events: auto;
+.infobox-back {
+    transform: rotateY(180deg);
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 #map-infobox .close-btn {
     position: absolute;
@@ -714,6 +743,7 @@ body.home-page::before {
     cursor: pointer;
     padding: 0.25rem 0.5rem;
     transition: color 0.2s ease;
+    z-index: 10; /* Ensure it's above other content */
 }
 #map-infobox .close-btn:hover {
     color: var(--text-primary);
@@ -773,17 +803,71 @@ body.home-page::before {
     display: flex;
     gap: 0.5rem;
     justify-content: center;
-    align-items: flex-start; /* Better alignment for varying aspect ratios */
-    height: 28vh; /* Responsive height based on viewport */
-    min-height: 160px; /* Minimum height for smaller screens */
-    max-height: 220px; /* Maximum height to match original design on large screens */
+    align-items: flex-start;
+    height: 28vh;
+    min-height: 160px;
+    max-height: 220px;
     margin: 0;
+    flex-grow: 1; /* Allow content to fill space */
 }
 .infobox-games img {
     height: 100%;
     width: auto;
     border-radius: 4px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.4);
+}
+.infobox-lore-details {
+    flex-grow: 1;
+    overflow-y: auto;
+    padding-right: 1rem; /* for scrollbar */
+    margin-right: -1rem;
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-relaxed);
+}
+.infobox-lore-details h4 {
+    color: var(--accent-gold);
+    font-weight: 700;
+    margin: 1rem 0 0.25rem 0;
+    font-size: var(--font-size-base);
+}
+.infobox-lore-details p {
+    margin: 0 0 0.75rem 0;
+    color: var(--text-primary);
+}
+.infobox-lore-details ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.infobox-lore-details ul li {
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: var(--font-size-xs);
+    margin-right: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.infobox-footer {
+    padding-top: 0.75rem;
+    margin-top: 0.5rem;
+    border-top: 1px solid rgba(233, 213, 161, 0.2);
+    text-align: center;
+}
+.toggle-lore-btn {
+    background: transparent;
+    border: 1px solid var(--text-secondary);
+    color: var(--text-secondary);
+    padding: 0.35rem 0.85rem;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    transition: all 0.2s ease-in-out;
+}
+.toggle-lore-btn:hover {
+    background: var(--accent-gold);
+    color: var(--primary-bg);
+    border-color: var(--accent-gold);
 }
 @media (min-width: 1200px) {
     .infobox-header h2 {


### PR DESCRIPTION
… display either game art or detailed lore.

This change involves a complete overhaul of the infobox's HTML, CSS, and JavaScript.

Key changes:
- **lore.html:** The `#map-infobox` element is restructured with a new `.infobox-flipper` container that holds a front and back face, allowing for a 3D flip effect.
- **style.css:** New CSS is added to implement the 3D flip animation. The front and back faces are styled, and a `.is-flipped` class is used to trigger the rotation. Styles are also added for the new lore details section and toggle buttons.
- **lore-script.js:** The old infobox logic is completely replaced. The new script now populates both sides of the card on region click, determines the default face based on the region's `regionType` (major/minor), and handles the flip animation via toggle buttons. The existing positioning and closing logic is preserved.