### PR TITLE
feat: Add fade-in/out animation for map infobox

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -578,9 +578,18 @@ body.home-page::before {
     box-shadow: 0 5px 20px rgba(0,0,0,0.5);
     color: #f0f0f0;
     font-family: 'Inter', sans-serif;
-    display: none; /* Initially hidden */
-    z-index: 1000;
+    z-index: 1001; /* Higher than header z-index */
     overflow: hidden; /* Ensures content respects border-radius */
+    opacity: 0;
+    transform: scale(0.95);
+    transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+    pointer-events: none;
+}
+
+.map-infobox.visible {
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
 }
 
 .map-infobox-header {


### PR DESCRIPTION
Implements a smooth fade and scale animation for the map infobox when it is opened and closed, replacing the previous jarring pop-in effect.

- In `style.css`, the infobox is now hidden using `opacity: 0` and `transform: scale(0.95)` instead of `display: none`.
- A `.visible` class is used to toggle the `opacity` and `transform` to their visible states.
- A CSS `transition` is applied to these properties to create the animation.
- The `z-index` of the infobox is increased to ensure it appears above the sticky header.

- In `lore.js`, the logic is refactored to add/remove the `.visible` class instead of manipulating the `display` style.
- The click handler for the map is updated to cleanly handle the closing and opening of the infobox.
- `requestAnimationFrame` is used when showing the infobox to ensure the animation is triggered reliably after positioning.