### PR TITLE
feat: implement smooth open/close animation for map infobox

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -73,7 +73,7 @@
         </div>
 
         <div id="map-view" class="tab-content">
-            <div id="map-infobox" class="map-infobox" style="display: none;"></div>
+            <div id="map-infobox" class="map-infobox"></div>
             <div class="full-width-section">
                 <h2>Interactive Map</h2>
                 <p style="font-size: 0.9em; font-style: italic; text-align: center; margin-bottom: 15px;">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -578,9 +578,23 @@ body.home-page::before {
     box-shadow: 0 5px 20px rgba(0,0,0,0.5);
     color: #f0f0f0;
     font-family: 'Inter', sans-serif;
-    display: none; /* Initially hidden */
     z-index: 1000;
     overflow: hidden; /* Ensures content respects border-radius */
+
+    /* Animation Properties */
+    visibility: hidden;
+    opacity: 0;
+    transform: scale(0.95);
+    transform-origin: top left;
+    transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out, visibility 0s 0.2s;
+}
+
+/* Use a more specific selector to ensure the transition override works */
+body #map-view .map-infobox.active {
+    visibility: visible;
+    opacity: 1;
+    transform: scale(1);
+    transition-delay: 0s; /* Override the closing delay for a snappy opening */
 }
 
 .map-infobox-header {


### PR DESCRIPTION
This commit introduces a CSS-based open and close animation for the map infobox and refactors the JavaScript to ensure it fires reliably.

The previous implementation, which manipulated the `display` property directly, often prevented the browser from correctly applying a CSS transition. This has been fixed by using a class-based state (`.active`) and controlling visibility with the `visibility` and `opacity` properties.

Key changes:
- Replaced `display: none` with a `visibility`/`opacity` and `transform` based animation in `style.css`.
- The opening animation is now a fade-in and scale-up effect from the top-left.
- The closing animation is a fade-out and scale-down.
- Refactored `lore.js` to add the `.active` class inside a `requestAnimationFrame` callback, ensuring the transition fires consistently.
- Improved the map click handler to allow the closing animation to complete before opening a new infobox.