### PR TITLE
Fix infobox animation and font loading bugs

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -587,14 +587,13 @@ body.home-page::before {
     opacity: 0;
     transform: scale(0.95);
     transform-origin: top left;
-    transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out, visibility 0s 0.2s;
+    transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
 }
 
 #map-infobox.active {
-    visibility: visible !important; /* Use important to override inline style */
     opacity: 1;
     transform: scale(1);
-    transition-delay: 0s;
+    transition-delay: 0s; /* Explicitly reset delay for the active state */
 }
 
 .map-infobox-header {


### PR DESCRIPTION
This commit addresses two subtle bugs in the map infobox:

1.  The initial height of the infobox was sometimes calculated incorrectly because it didn't wait for custom fonts to load. The height calculation logic is now wrapped in `document.fonts.ready` to ensure it runs after fonts are rendered.

2.  A "ghost box" issue occurred where the infobox, after being closed, would remain in the layout invisibly and block mouse events. This was fixed by:
    - Removing the delayed `visibility` from the CSS transition.
    - Adding a `transitionend` event listener in the JavaScript to set `display: none` on the infobox after the fade-out animation completes.