### PR TITLE
Fix(map): Correct infobox display logic to prevent disappearance

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -101,7 +101,7 @@
             </div>
 
             <!-- Static Infobox Structure -->
-            <div id="map-infobox" class="map-infobox" style="visibility: hidden;">
+            <div id="map-infobox" class="map-infobox">
                 <div class="map-infobox-header">
                     <!-- Header content will be injected by JS -->
                 </div>

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -544,14 +544,6 @@ export function initLorePage() {
             return;
         }
 
-        // Listen for the end of the fade-out transition to hide the box completely
-        infoboxEl.addEventListener('transitionend', () => {
-            // If the active class is not present, the box has just finished fading out
-            if (!infoboxEl.classList.contains('active')) {
-                infoboxEl.style.display = 'none';
-            }
-        });
-
         mapContainer.classList.add('is-loading');
 
         function hexToRgba(hex, alpha = 1) {
@@ -624,7 +616,13 @@ export function initLorePage() {
         if (!clickedRegionId || (isInfoboxActive && clickedRegionId === currentRegionId)) {
             infoboxEl.classList.remove('active');
             infoboxEl.dataset.regionId = '';
-            // The 'transitionend' event listener will now handle setting display to 'none'.
+            // The fade-out transition is 0.2s (200ms). We'll wait a bit longer.
+            setTimeout(() => {
+                // Check if it's still inactive before hiding, in case the user clicked again quickly
+                if (!infoboxEl.classList.contains('active')) {
+                    infoboxEl.style.display = 'none';
+                }
+            }, 250);
             return;
         }
         


### PR DESCRIPTION
This commit resolves a regression where the map infobox would not appear at all after a previous fix.

The root cause was an overly broad `transitionend` event listener that was incorrectly setting `display: none` on the infobox, preventing it from ever being shown.

The fix involves:
1. Removing the problematic `transitionend` listener.
2. Replacing it with a `setTimeout` in the `handleMapClick` function. This ensures the infobox is reliably hidden with `display: none` only after its fade-out animation completes, preserving the original 'ghost box' fix.
3. Removing a redundant inline `style="visibility: hidden;"` from the `lore.html` as the display is now managed entirely by CSS classes and JavaScript.