### PR TITLE
feat: Implement cross-fade transition for map infobox

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -101,21 +101,21 @@
             </div>
 
             <!-- Static Infobox Structure -->
-            <div id="map-infobox" class="map-infobox">
-                <div class="map-infobox-header">
-                    <!-- Header content will be injected by JS -->
-                </div>
+            <div id="map-infobox-1" class="map-infobox">
+                <div class="map-infobox-header"></div>
                 <div class="infobox-body">
-                    <div class="infobox-games-view">
-                        <!-- Games view content will be injected by JS -->
-                    </div>
-                    <div class="infobox-lore-view">
-                        <!-- Lore view content will be injected by JS -->
-                    </div>
+                    <div class="infobox-games-view"></div>
+                    <div class="infobox-lore-view"></div>
                 </div>
-                <div class="map-infobox-footer">
-                    <!-- Footer content (toggle button) will be injected by JS -->
+                <div class="map-infobox-footer"></div>
+            </div>
+            <div id="map-infobox-2" class="map-infobox">
+                <div class="map-infobox-header"></div>
+                <div class="infobox-body">
+                    <div class="infobox-games-view"></div>
+                    <div class="infobox-lore-view"></div>
                 </div>
+                <div class="map-infobox-footer"></div>
             </div>
         </div>
     </main>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -568,7 +568,7 @@ body.home-page::before {
 }
 
 /* --- Map Infobox --- */
-#map-infobox {
+.map-infobox {
     position: absolute;
     min-width: 320px;
     max-width: 90vw;
@@ -588,12 +588,15 @@ body.home-page::before {
     transform: scale(0.95);
     transform-origin: top left;
     transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+    /* By default, infoboxes are not clickable until active */
+    pointer-events: none;
 }
 
-#map-infobox.active {
+.map-infobox.active {
     opacity: 1;
     transform: scale(1);
     transition-delay: 0s; /* Explicitly reset delay for the active state */
+    pointer-events: auto; /* Make the active infobox clickable */
 }
 
 .map-infobox-header {
@@ -655,11 +658,11 @@ body.home-page::before {
 }
 
 /* State Modifier: Show Lore View */
-#map-infobox.show-lore-view .infobox-games-view {
+.map-infobox.show-lore-view .infobox-games-view {
     opacity: 0;
     visibility: hidden;
 }
-#map-infobox.show-lore-view .infobox-lore-view {
+.map-infobox.show-lore-view .infobox-lore-view {
     opacity: 1;
     visibility: visible;
 }


### PR DESCRIPTION
Refactors the map infobox functionality to use a simultaneous cross-fade transition when switching between different regions. This replaces the previous sequential fade-out/fade-in effect, improving visual fluidity and responsiveness.

- Duplicates the infobox element in `lore.html` to enable two boxes to be managed at once.
- Updates CSS selectors in `src/css/style.css` from ID to class-based to apply styles to both elements.
- Rewrites the map logic in `src/js/lore.js` to orchestrate the cross-fade. It now prepares the incoming infobox in the background and then toggles the active classes on both the old and new boxes to trigger a simultaneous animation.