### PR TITLE
refactor(map): Move capital info and add wiki link to infobox

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -633,6 +633,28 @@ body.home-page::before {
     color: #b0b0b0;
 }
 
+.map-infobox-links {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.map-infobox-links a {
+    display: inline-block;
+    line-height: 0; /* Remove extra space below the image */
+}
+
+.map-infobox-links img {
+    height: 40px;
+    width: auto;
+    opacity: 0.7;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.map-infobox-links img:hover {
+    opacity: 1;
+}
+
 .infobox-body {
     position: relative;
     transition: height 0.25s ease-in-out;

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -668,8 +668,10 @@ export function initLorePage() {
                 <h3>${region.name}</h3>
                 <p>${region.government}</p>
             </div>
-            <div class="map-infobox-stats">
-                <strong>Capital:</strong><br>${region.capital}
+            <div class="map-infobox-links">
+                <a href="${region.wikiLink}" target="_blank" rel="noopener noreferrer" title="View on Kiseki Wiki">
+                    <img src="assets/logo/fandom.webp" alt="Fandom Wiki">
+                </a>
             </div>
         `;
 
@@ -689,6 +691,10 @@ export function initLorePage() {
                 <ul>${featuredInGames.map(game => `<li>${game.englishTitle}</li>`).join('')}</ul>
             </div>` : '';
         loreViewEl.innerHTML = `
+            <div class="map-infobox-lore-section">
+                <h4 style="color: ${region.baseColor}; border-bottom-color: ${region.baseColor};">Region Details</h4>
+                <p><strong>Capital:</strong> ${region.capital}</p>
+            </div>
             <div class="map-infobox-lore-section">
                 <h4 style="color: ${region.baseColor}; border-bottom-color: ${region.baseColor};">Description</h4>
                 <p>${region.description}</p>


### PR DESCRIPTION
- Moves the 'Capital' information from the header of the map info-box to a new 'Region Details' section in the lore view.
- Adds a Fandom wiki link with an icon in the place of the capital information.
- Increases the size of the wiki link icon to match the region emblem.