### PR TITLE
feat: Adjust map infobox display for minor regions and regions withou…

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -609,6 +609,10 @@ body.home-page::before {
     border-bottom: 1px solid #444;
 }
 
+.map-infobox-header.no-emblem {
+    grid-template-columns: 1fr 80px;
+}
+
 .map-infobox-emblem {
     width: 40px;
     height: 40px;

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -667,8 +667,14 @@ export function initLorePage() {
         const bodyEl = infoboxEl.querySelector('.infobox-body');
 
         // Populate Header
-        headerEl.innerHTML = `
-            <img src="assets/logo/${region.emblemAsset}" alt="${region.name} Emblem" class="map-infobox-emblem">
+        const hasEmblem = region.emblemAsset;
+        headerEl.classList.toggle('no-emblem', !hasEmblem);
+
+        let headerHTML = '';
+        if (hasEmblem) {
+            headerHTML += `<img src="assets/logo/${region.emblemAsset}" alt="${region.name} Emblem" class="map-infobox-emblem">`;
+        }
+        headerHTML += `
             <div class="map-infobox-title-section">
                 <h3>${region.name}</h3>
                 <p>${region.government}</p>
@@ -679,6 +685,7 @@ export function initLorePage() {
                 </a>
             </div>
         `;
+        headerEl.innerHTML = headerHTML;
 
         // Populate Games View
         const gamesInRegion = mapGamesData.filter(game => (region.games || []).includes(game.id));
@@ -715,6 +722,7 @@ export function initLorePage() {
         // Populate Footer & Set Up Toggle
         footerEl.innerHTML = '';
         if (region.regionType === 'major') {
+            footerEl.style.display = 'block';
             const toggleButton = document.createElement('button');
             toggleButton.className = 'map-infobox-toggle-btn';
             
@@ -731,6 +739,8 @@ export function initLorePage() {
             
             footerEl.appendChild(toggleButton);
             updateButtonText();
+        } else {
+            footerEl.style.display = 'none';
         }
     }
 


### PR DESCRIPTION
…t emblems

This commit introduces two visual adjustments to the map infobox:

1.  The footer of the infobox is now hidden for minor regions, as it contains functionality (toggling between lore and game art) that is only relevant for major regions. This is achieved by setting the footer element's display style to 'none' when a minor region is selected.

2.  The infobox header now correctly handles regions that do not have an emblem. For these regions, the emblem is omitted from the header, and the CSS is adjusted to ensure the region's name and government details are properly left-aligned.