### PR TITLE
Refactor map infobox header to handle missing emblems

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -601,16 +601,12 @@ body.home-page::before {
 
 .map-infobox-header {
     display: grid;
-    grid-template-columns: 40px 1fr 80px;
+    /* The grid-template-columns are now set dynamically via JS */
     align-items: center;
     gap: 10px;
     padding: 10px;
     background-color: #252525;
     border-bottom: 1px solid #444;
-}
-
-.map-infobox-header.no-emblem {
-    grid-template-columns: 1fr 80px;
 }
 
 .map-infobox-emblem {

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -668,7 +668,11 @@ export function initLorePage() {
 
         // Populate Header
         const hasEmblem = region.emblemAsset;
-        headerEl.classList.toggle('no-emblem', !hasEmblem);
+        if (hasEmblem) {
+            headerEl.style.gridTemplateColumns = '40px 1fr auto';
+        } else {
+            headerEl.style.gridTemplateColumns = '1fr auto';
+        }
 
         let headerHTML = '';
         if (hasEmblem) {


### PR DESCRIPTION
Moves the layout logic for the map infobox header from a CSS class-based system to direct JavaScript manipulation. This ensures that when a region does not have an emblem, the header's grid layout is adjusted to a two-column format, correctly anchoring the title and government to the left.

- Modified `src/js/lore.js` to dynamically set `grid-template-columns` on the header element based on the presence of `emblemAsset`.
- Removed the now-redundant `.no-emblem` class and associated static grid layout from `src/css/style.css`.