### PR TITLE
Fix map info-box UI glitches and improve consistency

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -568,6 +568,11 @@ body.home-page::before {
 }
 
 /* --- Map Infobox --- */
+/* Utility class to disable transitions during JS calculations */
+.no-transition {
+    transition: none !important;
+}
+
 .map-infobox {
     position: absolute;
     min-width: 320px;

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -723,6 +723,10 @@ export function initLorePage() {
             ${featuredInHtml}
         `;
 
+        // Set initial view state first, so the button text is correct.
+        const showLoreInitially = region.regionType !== 'major';
+        infoboxEl.classList.toggle('show-lore-view', showLoreInitially);
+
         // Populate Footer & Set Up Toggle
         footerEl.innerHTML = '';
         if (region.regionType === 'major') {
@@ -742,7 +746,7 @@ export function initLorePage() {
             });
             
             footerEl.appendChild(toggleButton);
-            updateButtonText();
+            updateButtonText(); // Now this will be correct.
         } else {
             footerEl.style.display = 'none';
         }
@@ -770,10 +774,6 @@ export function initLorePage() {
             infoboxEl.style.width = '320px';
         }
 
-        // Set initial view state
-        const showLoreInitially = region.regionType !== 'major';
-        infoboxEl.classList.toggle('show-lore-view', showLoreInitially);
-
         // --- Image and Font Loading Fix ---
         const images = gamesViewEl.querySelectorAll('img');
         const imageLoadPromises = [...images].map(img => {
@@ -785,8 +785,23 @@ export function initLorePage() {
         });
 
         return Promise.all([document.fonts.ready, ...imageLoadPromises]).then(() => {
-            const initialView = showLoreInitially ? loreViewEl : gamesViewEl;
+            // The 'show-lore-view' class is now set in updateInfoboxContents.
+            // We just need to read it here to determine the initial view for height calculation.
+            const initialView = infoboxEl.classList.contains('show-lore-view') ? loreViewEl : gamesViewEl;
+
+            // --- Height Calculation & Transition Fix ---
+            // 1. Add a class to disable transitions on the body.
+            bodyEl.classList.add('no-transition');
+            // 2. Set the height instantaneously.
             bodyEl.style.height = `${initialView.scrollHeight}px`;
+
+            // 3. Force a reflow. Accessing offsetHeight is a common way to do this.
+            // This ensures the browser applies the height change before we re-enable transitions.
+            void bodyEl.offsetHeight;
+
+            // 4. Remove the no-transition class so future toggles are animated.
+            bodyEl.classList.remove('no-transition');
+
 
             // Position the infobox
             const rect = infoboxEl.getBoundingClientRect();


### PR DESCRIPTION
This commit addresses three separate but related issues with the map info-boxes on the lore page:

1.  **Incorrect Button Text:** The toggle button would sometimes display "Show Game Art" when it should have said "View Lore Details." This was caused by the button's text being determined before the infobox's view state was properly reset. The fix consolidates the state-setting logic to ensure the correct state is established before the button is rendered.

2.  **Animation Glitches:** When opening, info-boxes would visibly shrink or grow vertically. This was due to a CSS height transition firing when the initial height was set via JavaScript. The fix is to temporarily disable the transition using a helper class while the initial height is set, then re-enable it for subsequent user interactions.

3.  **Incorrect Positioning:** Info-boxes would sometimes appear far above their intended position. This was a side effect of the animation glitch, where the box's height was being measured for positioning calculations while it was still animating. By fixing the animation glitch, the height is now stable and correct when measured, ensuring accurate positioning.