### PR TITLE
feat: Make map hover effects more subtle

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -841,7 +841,7 @@ body.home-page::before {
     pointer-events: none;
 }
 .map-container:hover .dimming-rect {
-    opacity: 1;
+    opacity: 0.6;
 }
 .map-overlay-svg {
     position: absolute;
@@ -855,13 +855,13 @@ body.home-page::before {
     fill: transparent;
     stroke: transparent;
     stroke-width: 3;
-    transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out;
+    transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out, stroke-width 0.2s ease-in-out;
     cursor: pointer;
 }
 .region-path:hover {
     fill: var(--region-highlight-color);
-    stroke: var(--accent-gold);
-    stroke-width: 4;
+    stroke: rgba(255, 255, 255, 0.7);
+    stroke-width: 2.5;
 }
 
 /*

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -584,7 +584,7 @@ export function initLorePage() {
                 path.id = `region-${region.id}`;
                 path.dataset.regionId = region.id;
                 if (region.baseColor) {
-                    path.style.setProperty('--region-highlight-color', hexToRgba(region.baseColor, 0.7));
+                    path.style.setProperty('--region-highlight-color', hexToRgba(region.baseColor, 0.4));
                 }
                 mapOverlay.appendChild(path);
 


### PR DESCRIPTION
This commit updates the map hover effects to be more subtle and tasteful.

The changes include:
- Reducing the opacity of the region highlight fill from 0.7 to 0.4.
- Changing the region stroke on hover to a semi-transparent white and reducing its width from 4px to 2.5px.
- Reducing the opacity of the background dimming effect from 1 to 0.6.
- Adding a CSS transition for the stroke-width to improve smoothness.