### PR TITLE
Fix timeline race condition on lore page

### DIFF
--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -2,6 +2,7 @@ import { calculateRegionAreaInSelge } from './lib/geometry.js';
 
 export function initLorePage() {
     let isMapInitialized = false;
+    let isTimelineInitialized = false;
     let infobox1, infobox2, currentInfobox; // Variables for the two infobox elements and state tracking
 
     // --- Tabbed Interface Logic ---
@@ -21,6 +22,8 @@ export function initLorePage() {
         if (initialActiveContent) {
             if (initialActiveContent.id === 'map-view' && !isMapInitialized) {
                 initializeMap();
+            } else if (initialActiveContent.id === 'timeline-view' && !isTimelineInitialized) {
+                initializeTimelineView();
             }
             // Add 'show' class to make it visible with fade-in effect
             setTimeout(() => initialActiveContent.classList.add('show'), 10);
@@ -36,9 +39,11 @@ export function initLorePage() {
             const targetTabContentId = clickedTab.dataset.tab;
             localStorage.setItem('loreLastTab', targetTabContentId); // Save selection
 
-            // Initialize map if it's being shown for the first time
+            // Initialize map or timeline if it's being shown for the first time
             if (targetTabContentId === 'map-view' && !isMapInitialized) {
                 initializeMap();
+            } else if (targetTabContentId === 'timeline-view' && !isTimelineInitialized) {
+                initializeTimelineView();
             }
 
             const targetTabContent = document.getElementById(targetTabContentId);
@@ -99,6 +104,12 @@ export function initLorePage() {
     function dateToTotalMonths(parsedDate) {
         if (!parsedDate) return Infinity;
         return parsedDate.year * 12 + parsedDate.month;
+    }
+
+    function initializeTimelineView() {
+        if (isTimelineInitialized) return;
+        isTimelineInitialized = true;
+        initializeTimeline();
     }
 
     async function initializeTimeline() {
@@ -524,8 +535,6 @@ export function initLorePage() {
             }
         }); // End of game loop
     }
-
-    initializeTimeline();
 
     // --- Map Logic & Data ---
     let mapRegionsData = [];


### PR DESCRIPTION
The title and dates for Trails of Cold Steel IV on the lore timeline page were sometimes displaying at the top of the column. This was caused by a race condition where the timeline rendering logic would run before the timeline tab was visible, causing the browser to report incorrect element dimensions.

This change defers the timeline initialization until the timeline tab is visible, ensuring that the browser has computed the correct layout information before the positioning script runs.