### PR TITLE
feat: Create mobile-friendly lore page interface

### DIFF
--- a/jules-scratch/verification/verify_lore_mobile.py
+++ b/jules-scratch/verification/verify_lore_mobile.py
@@ -1,0 +1,49 @@
+import os
+from playwright.sync_api import sync_playwright, Page, expect
+
+def verify_lore_mobile(page: Page):
+    """
+    This test verifies that the mobile interface for the Lore page
+    renders correctly and that tab navigation works.
+    """
+    # 1. Arrange: Go to the lore page.
+    # The path needs to be absolute.
+    file_path = f"file://{os.getcwd()}/lore.html"
+    page.goto(file_path)
+
+    # 2. Set viewport to a mobile size.
+    page.set_viewport_size({"width": 375, "height": 812})
+
+    # 3. Assert: Check that the mobile map view is visible by default.
+    # Wait for the region list to be populated, which indicates rendering is complete.
+    expect(page.locator(".mobile-region-list")).to_be_visible()
+
+    # The title of the map view should be visible.
+    mobile_map_title = page.locator(".mobile-map-title")
+    expect(mobile_map_title).to_be_visible()
+    expect(mobile_map_title).to_have_text("Map of Zemuria")
+
+    # Take a screenshot of the map view.
+    page.screenshot(path="jules-scratch/verification/verification_map.png")
+
+    # 4. Act: Find the "Timeline" link and click it.
+    timeline_link = page.get_by_role("link", name="Timeline")
+    timeline_link.click()
+
+    # 5. Assert: Check that the mobile timeline view is visible.
+    # The first arc title should be visible.
+    mobile_timeline_title = page.locator(".mobile-arc-title").first
+    expect(mobile_timeline_title).to_be_visible()
+    expect(mobile_timeline_title).to_have_text("Liberl Arc")
+
+    # Take a screenshot of the timeline view.
+    page.screenshot(path="jules-scratch/verification/verification_timeline.png")
+
+
+# Boilerplate to run the test
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        verify_lore_mobile(page)
+        browser.close()

--- a/lore.html
+++ b/lore.html
@@ -43,7 +43,7 @@
     </header>
 
     <main class="main-lore">
-        <div id="timeline-view" class="tab-content">
+        <div id="timeline-view" class="tab-content desktop-only-lore">
             <div class="timeline-section">
                 <h2>Lore Timeline</h2>
 
@@ -88,7 +88,7 @@
             </div>
         </div>
 
-        <div id="map-view" class="tab-content">
+        <div id="map-view" class="tab-content desktop-only-lore">
             <div class="full-width-section">
                 <h2>Interactive Map</h2>
                 <p style="font-size: 0.9em; font-style: italic; text-align: center; margin-bottom: 15px;">
@@ -134,6 +134,10 @@
                 <div class="map-infobox-footer"></div>
             </div>
         </div>
+
+        <!-- Mobile-specific containers -->
+        <div id="mobile-timeline-view" class="tab-content mobile-only-lore"></div>
+        <div id="mobile-map-view" class="tab-content mobile-only-lore"></div>
     </main>
 
     <footer>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -889,11 +889,11 @@ body.home-page::before {
     .slider-item {
         padding-bottom: 0;
     }
-    .desktop-only {
+    .desktop-only, .desktop-only-lore {
         display: none !important;
     }
-    .mobile-only {
-        display: block;
+    .mobile-only, .mobile-only-lore {
+        display: block !important;
     }
     .game-entry {
         padding: 0;
@@ -1088,7 +1088,109 @@ body.home-page::before {
         display: none !important;
     }
 
-    /* 7.4. Mobile Home Page */
+    /* 7.4. Mobile Lore Page */
+    .mobile-map-content, .mobile-timeline-content {
+        padding: 1rem 0.5rem;
+    }
+    .mobile-arc-section {
+        margin-bottom: 2rem;
+    }
+    .mobile-arc-title {
+        font-family: 'Playfair Display', serif;
+        font-size: var(--font-size-xxl);
+        color: var(--accent-gold);
+        text-align: center;
+        border-bottom: 1px solid var(--accent-gold);
+        padding-bottom: 0.5rem;
+        margin-bottom: 1rem;
+    }
+    .mobile-game-entry {
+        background-color: rgba(255, 255, 255, 0.05);
+        border-radius: 8px;
+        padding: 1rem;
+        margin-bottom: 1rem;
+        border-left: 4px solid var(--accent-gold);
+    }
+    .mobile-game-title {
+        font-size: var(--font-size-lg);
+        margin: 0 0 0.5rem 0;
+        color: var(--text-primary);
+    }
+    .mobile-game-period {
+        font-size: var(--font-size-sm);
+        color: var(--text-secondary);
+        margin: 0;
+        line-height: var(--line-height-normal);
+    }
+    .mobile-game-period strong {
+        color: var(--accent-gold);
+        font-weight: 600;
+    }
+    .mobile-map-title {
+        font-family: 'Playfair Display', serif;
+        font-size: var(--font-size-xxl);
+        color: var(--accent-gold);
+        text-align: center;
+        margin-bottom: 1rem;
+    }
+    .mobile-map-image {
+        width: 100%;
+        height: auto;
+        border-radius: 8px;
+        border: 2px solid var(--accent-gold);
+        margin-bottom: 1.5rem;
+    }
+    .mobile-region-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+    .mobile-region-header {
+        width: 100%;
+        background-color: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(233, 213, 161, 0.2);
+        border-radius: 6px;
+        padding: 0.75rem 1rem;
+        font-size: var(--font-size-md);
+        color: var(--text-primary);
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        text-align: left;
+        transition: background-color 0.2s ease;
+    }
+    .mobile-region-header:hover, .mobile-region-header.active {
+        background-color: rgba(233, 213, 161, 0.15);
+    }
+    .accordion-icon {
+        font-size: 1.5em;
+        line-height: 1;
+        color: var(--accent-gold);
+        transition: transform 0.3s ease;
+    }
+    .mobile-region-body {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease-out;
+        background-color: rgba(0, 0, 0, 0.2);
+        border-radius: 0 0 6px 6px;
+    }
+    .mobile-region-details {
+        padding: 1rem;
+        font-size: var(--font-size-sm);
+        color: var(--text-secondary);
+        line-height: var(--line-height-normal);
+    }
+    .mobile-region-details p {
+        margin: 0 0 0.5rem 0;
+    }
+    .mobile-region-details p:last-child {
+        margin-bottom: 0;
+    }
+
+
+    /* 7.5. Mobile Home Page */
     .hero-section {
         min-height: 60vh;
         padding: 1rem;
@@ -1117,6 +1219,9 @@ body.home-page::before {
 
 /* --- Initial Hiding of Mobile/Desktop Specific Elements --- */
 /* This is out of the media query to ensure it's a base style. */
-.mobile-only {
+.mobile-only, .mobile-only-lore {
     display: none;
+}
+.desktop-only-lore {
+    display: block;
 }

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -7,25 +7,6 @@ export function initLorePage() {
     // --- Tabbed Interface Logic ---
     const tabsContainer = document.querySelector('.lore-tabs');
     if (tabsContainer) {
-        // Determine the tab to show: saved tab or default to 'map-view'.
-        const tabIdToShow = localStorage.getItem('loreLastTab') || 'map-view';
-
-        // Apply 'active' to the determined tab and its content.
-        const tabLinkToShow = document.querySelector(`.tab-link[data-tab="${tabIdToShow}"]`);
-        const contentToShow = document.getElementById(tabIdToShow);
-        if (tabLinkToShow) tabLinkToShow.classList.add('active');
-        if (contentToShow) contentToShow.classList.add('active');
-
-        // Check if the map is the active tab on load (either default or from storage) and initialize it
-        const initialActiveContent = document.querySelector('.tab-content.active');
-        if (initialActiveContent) {
-            if (initialActiveContent.id === 'map-view' && !isMapInitialized) {
-                initializeMap();
-            }
-            // Add 'show' class to make it visible with fade-in effect
-            setTimeout(() => initialActiveContent.classList.add('show'), 10);
-        }
-
         tabsContainer.addEventListener('click', (e) => {
             const clickedTab = e.target.closest('.tab-link');
             if (!clickedTab || clickedTab.classList.contains('active')) {
@@ -101,29 +82,46 @@ export function initLorePage() {
         return parsedDate.year * 12 + parsedDate.month;
     }
 
-    async function initializeTimeline() {
+    async function loadAllData() {
         try {
-            const response = await fetch('src/data/games.json');
-            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-            const rawGames = await response.json();
-            
+            const [gamesResponse, regionsResponse] = await Promise.all([
+                fetch('src/data/games.json'),
+                fetch('src/data/regions.json')
+            ]);
+
+            if (!gamesResponse.ok) throw new Error(`HTTP error! status: ${gamesResponse.status}`);
+            if (!regionsResponse.ok) throw new Error(`HTTP error! status: ${regionsResponse.status}`);
+
+            const rawGames = await gamesResponse.json();
+            const regions = await regionsResponse.json();
+
+            // Process game data (for timeline)
             allGames = processGameData(rawGames);
-            if (allGames.length === 0) {
-                console.warn("No valid game data to display.");
-                return;
+            if (allGames.length > 0) {
+                calculateDateRange();
             }
 
-            calculateDateRange(); // This will now use timelinePeriods
-            if (!minDate || !maxDate) {
-                console.error("Date range not calculated, cannot render timeline.");
-                return;
-            }
-            renderTimeAxis();
-            renderGameEntries();
+            // Process region data (for map)
+            mapRegionsData = regions.map(region => ({
+                ...region,
+                formattedArea: calculateRegionAreaInSelge(region)
+            }));
+            mapGamesData = rawGames; // Keep raw games data for map infoboxes
 
+            return true;
         } catch (error) {
-            console.error("Error initializing timeline:", error);
+            console.error("Error loading page data:", error);
+            return false;
         }
+    }
+
+    function renderDesktopTimeline() {
+        if (!minDate || !maxDate) {
+            console.error("Date range not calculated, cannot render desktop timeline.");
+            return;
+        }
+        renderTimeAxis();
+        renderGameEntries();
     }
 
     function processGameData(rawGames) {
@@ -495,7 +493,194 @@ export function initLorePage() {
         }); // End of game loop
     }
 
-    initializeTimeline();
+    function renderMobileMap() {
+        if (!mapRegionsData || mapRegionsData.length === 0) {
+            console.warn("Cannot render mobile map: missing region data.");
+            return;
+        }
+
+        const container = document.getElementById('mobile-map-view');
+        if (!container) {
+            console.warn("Mobile map container not found.");
+            return;
+        }
+
+        let html = `
+            <div class="mobile-map-content">
+                <h2 class="mobile-map-title">Map of Zemuria</h2>
+                <img src="assets/zemuria-map.webp" alt="Map of Zemuria" class="mobile-map-image">
+                <div class="mobile-region-list">
+        `;
+
+        // Sort regions, maybe alphabetically
+        const sortedRegions = [...mapRegionsData].sort((a, b) => a.name.localeCompare(b.name));
+
+        sortedRegions.forEach(region => {
+            html += `
+                <div class="mobile-region-item">
+                    <button class="mobile-region-header" data-region-id="${region.id}">
+                        <span>${region.name}</span>
+                        <span class="accordion-icon">+</span>
+                    </button>
+                    <div class="mobile-region-body" id="mobile-region-body-${region.id}">
+                        <div class="mobile-region-details">
+                            <p><strong>Government:</strong> ${region.government}</p>
+                            <p><strong>Capital:</strong> ${region.capital}</p>
+                            ${region.description ? `<p>${region.description}</p>` : ''}
+                        </div>
+                    </div>
+                </div>
+            `;
+        });
+
+        html += `</div></div>`;
+        container.innerHTML = html;
+
+        // Add event listeners for accordion functionality
+        container.addEventListener('click', (e) => {
+            const header = e.target.closest('.mobile-region-header');
+            if (!header) return;
+
+            const body = header.nextElementSibling;
+            const icon = header.querySelector('.accordion-icon');
+
+            if (body.style.maxHeight) {
+                body.style.maxHeight = null;
+                icon.textContent = '+';
+                header.classList.remove('active');
+            } else {
+                body.style.maxHeight = body.scrollHeight + "px";
+                icon.textContent = '−';
+                header.classList.add('active');
+            }
+        });
+    }
+
+    // --- Mobile Timeline Rendering ---
+    function renderMobileTimeline() {
+        if (!allGames || allGames.length === 0) {
+            console.warn("Cannot render mobile timeline: missing game data.");
+            return;
+        }
+
+        const container = document.getElementById('mobile-timeline-view');
+        if (!container) {
+            console.warn("Mobile timeline container not found.");
+            return;
+        }
+
+        // Group games by arc
+        const gamesByArc = allGames.reduce((acc, game) => {
+            if (!game.timelinePeriodsParsed || game.timelinePeriodsParsed.length === 0) {
+                return acc; // Skip games with no timeline data
+            }
+            const arc = game.arc;
+            if (!acc[arc]) {
+                acc[arc] = [];
+            }
+            acc[arc].push(game);
+            return acc;
+        }, {});
+
+        // Define the desired order of arcs
+        const arcOrder = ["Liberl Arc", "Crossbell Arc", "Erebonia Arc", "Epilogue", "Calvard Arc"];
+
+        let html = '<div class="mobile-timeline-content">';
+
+        for (const arcName of arcOrder) {
+            if (gamesByArc[arcName]) {
+                html += `<div class="mobile-arc-section">`;
+                html += `<h2 class="mobile-arc-title">${arcName}</h2>`;
+
+                // Sort games within the arc based on their first timeline period's start date
+                const sortedGames = gamesByArc[arcName].sort((a, b) => {
+                    const aDate = dateToTotalMonths(a.timelinePeriodsParsed[0].startParsed);
+                    const bDate = dateToTotalMonths(b.timelinePeriodsParsed[0].startParsed);
+                    return aDate - bDate;
+                });
+
+                for (const game of sortedGames) {
+                    html += `<div class="mobile-game-entry">`;
+                    html += `<h3 class="mobile-game-title">${game.englishTitle}</h3>`;
+
+                    // Display all periods for the game
+                    game.timelinePeriodsParsed.forEach(period => {
+                        let periodText = '';
+                        if (period.label) {
+                            periodText += `<strong>${period.label}:</strong> `;
+                        }
+                        periodText += period.display;
+                        html += `<p class="mobile-game-period">${periodText}</p>`;
+                    });
+
+                    html += `</div>`;
+                }
+                html += `</div>`;
+            }
+        }
+
+        html += '</div>';
+        container.innerHTML = html;
+    }
+
+
+    // --- Main Initialization Logic ---
+    loadAllData().then(dataLoaded => {
+        if (!dataLoaded) return;
+
+        const isMobile = window.innerWidth <= 900;
+
+        // Adjust tab links for mobile
+        if (isMobile) {
+            const mapTabLink = document.querySelector('.tab-link[data-tab="map-view"]');
+            const timelineTabLink = document.querySelector('.tab-link[data-tab="timeline-view"]');
+            if (mapTabLink) mapTabLink.dataset.tab = 'mobile-map-view';
+            if (timelineTabLink) timelineTabLink.dataset.tab = 'mobile-timeline-view';
+        }
+
+        // Render the correct view
+        if (isMobile) {
+            renderMobileTimeline();
+            renderMobileMap();
+        } else {
+            renderDesktopTimeline();
+        }
+
+        // The tab switching logic is generic, but the default tab needs to be set correctly.
+        const initialTabId = localStorage.getItem('loreLastTab') || (isMobile ? 'mobile-map-view' : 'map-view');
+
+        // Let's check if the stored tab is valid for the current view (mobile/desktop)
+        let validTabId = initialTabId;
+        if (isMobile && !initialTabId.startsWith('mobile-')) {
+            validTabId = 'mobile-map-view'; // Default to mobile map
+        } else if (!isMobile && initialTabId.startsWith('mobile-')) {
+            validTabId = 'map-view'; // Default to desktop map
+        }
+
+        const tabLinkToShow = document.querySelector(`.tab-link[data-tab="${validTabId}"]`);
+        const contentToShow = document.getElementById(validTabId);
+
+        // Deactivate all first
+        document.querySelectorAll('.tab-link').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => {
+            c.classList.remove('active', 'show');
+        });
+
+        if (tabLinkToShow && contentToShow) {
+            tabLinkToShow.classList.add('active');
+            contentToShow.classList.add('active');
+
+            if (contentToShow.id === 'map-view' && !isMapInitialized) {
+                initializeMap();
+            }
+            // Add 'show' class to make it visible with fade-in effect
+            setTimeout(() => contentToShow.classList.add('show'), 10);
+        }
+
+        // The original tab click listener should still work, as it's generic enough.
+        // Let's ensure it's placed correctly, after the main logic.
+    });
+
 
     // --- Map Logic & Data ---
     let mapRegionsData = [];


### PR DESCRIPTION
This commit introduces a new, from-scratch mobile interface for the Lore page. The existing desktop view was not suitable for small screens.

Key changes:
- Added new HTML containers in `lore.html` specifically for the mobile view (`#mobile-timeline-view`, `#mobile-map-view`).
- Implemented CSS rules in `src/css/style.css` to create a responsive layout that shows the mobile-specific view on screens up to 900px wide, and hides the desktop view.
- Created a mobile-friendly timeline that displays as a simple, vertical list grouped by game arc.
- Implemented a mobile-friendly map view that shows the map image followed by an accordion-style list of regions for easy exploration.
- Refactored `src/js/lore.js` to support both mobile and desktop views. It now detects the screen size and calls the appropriate rendering functions, ensuring efficient data loading and a seamless user experience.