### PR TITLE
This change introduces a new system to allow game entries on the lore…

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -762,6 +762,9 @@ body.home-page::before {
     align-items: center;
     text-align: center;
 }
+.game-entry-box.spans-arcs {
+    z-index: 5; /* Ensure it renders above column borders */
+}
 .game-entry-box.special-info-below {
     overflow: visible;
 }

--- a/src/data/games.json
+++ b/src/data/games.json
@@ -506,7 +506,7 @@
   },
   {
     "id": "trails-into-reverie",
-    "arc": "Epilogue",
+    "spansArcs": ["Crossbell Arc", "Erebonia Arc"],
     "englishTitle": "Trails into Reverie",
     "japaneseTitleKanji": "英雄伝説 創の軌跡",
     "japaneseTitleRomaji": "Hajimari no Kiseki",

--- a/src/js/lore.js
+++ b/src/js/lore.js
@@ -300,17 +300,27 @@ export function initLorePage() {
             }
 
             let targetColumn;
-            if (game.arc === "Liberl Arc") targetColumn = liberlColumn;
-            else if (game.arc === "Crossbell Arc") targetColumn = crossbellColumn;
-            else if (game.arc === "Erebonia Arc" || game.englishTitle === "Trails into Reverie") targetColumn = ereboniaColumn;
-            else if (game.arc === "Calvard Arc") targetColumn = calvardColumn;
-            else {
-                console.warn(`Game "${game.englishTitle}" arc "${game.arc}" unassigned. Skipping rendering.`);
-                return;
+            let columnSpan = 1;
+
+            // Define a map for easy lookup
+            const arcColumnMap = {
+                "Liberl Arc": liberlColumn,
+                "Crossbell Arc": crossbellColumn,
+                "Erebonia Arc": ereboniaColumn,
+                "Calvard Arc": calvardColumn
+            };
+
+            if (game.spansArcs && Array.isArray(game.spansArcs) && game.spansArcs.length > 0) {
+                const firstArc = game.spansArcs[0];
+                targetColumn = arcColumnMap[firstArc];
+                columnSpan = game.spansArcs.length;
+            } else if (game.arc) {
+                targetColumn = arcColumnMap[game.arc];
             }
 
             if (!targetColumn) {
-                console.warn(`Target column not found for game "${game.englishTitle}". Skipping rendering.`);
+                const arcIdentifier = game.spansArcs ? `spansArcs: [${game.spansArcs.join(', ')}]` : `arc: ${game.arc}`;
+                console.warn(`Game "${game.englishTitle}" (${arcIdentifier}) could not be assigned to a column. Skipping rendering.`);
                 return;
             }
 
@@ -384,8 +394,19 @@ export function initLorePage() {
                 gameEntryDiv.style.color = game.englishTitle === "Trails in the Sky SC" || game.englishTitle === "Trails through Daybreak" ? '#000000' : '#FFFFFF';
                 gameEntryDiv.style.top = `${topPosition + 2}px`; // -1 for border adjustment, +3 for shift
                 gameEntryDiv.style.height = `${entryHeight}px`;
-                gameEntryDiv.style.width = '90%';
+
+                if (columnSpan > 1) {
+                    gameEntryDiv.classList.add('spans-arcs');
+                    // The width needs to be 100% of the number of columns, plus the padding/border space between them.
+                    // Each column has 15px padding on each side, and a 1px border on the right.
+                    // So the space between two columns' content is 15px + 1px + 15px = 31px.
+                    // Let's use 32px for simplicity.
+                    gameEntryDiv.style.width = `calc(${100 * columnSpan}% + ${32 * (columnSpan - 1)}px)`;
+                } else {
+                    gameEntryDiv.style.width = '90%';
+                }
                 gameEntryDiv.style.left = '5%';
+
                 gameEntryDiv.dataset.gameTitle = game.englishTitle;
                 gameEntryDiv.dataset.periodIndex = periodIndex;
 


### PR DESCRIPTION
… timeline to span across multiple arc columns.

Key changes:
- A new `spansArcs` array property has been added to the `games.json` data structure. This allows a game to be associated with multiple timeline columns.
- The "Trails into Reverie" game data has been updated to use this new property, specifying that it should span the "Crossbell Arc" and "Erebonia Arc".
- The rendering logic in `src/js/lore.js` has been updated to handle the `spansArcs` property. It now dynamically calculates the width of the game entry to span the correct number of columns.
- A new CSS class, `.spans-arcs`, has been added to `src/css/style.css` to ensure the spanning elements are layered correctly with a `z-index`.

This implementation is data-driven and robust, making it easy to apply this spanning behavior to other games in the future without further code changes.