### PR TITLE
Improve SEO for page titles and meta descriptions

### DIFF
--- a/games.html
+++ b/games.html
@@ -3,22 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Trails/Kiseki Series Release Timeline - Zemurian Atlas</title>
-    <meta name="description" content="A complete timeline of all Trails (Kiseki) series games, from original Japanese releases to worldwide localizations. Track every title from 2004 to upcoming releases.">
-    <meta name="keywords" content="Trails of Cold Steel, Trails in the Sky, Trails from Zero, Trails to Azure, Trails into Reverie, release dates, localization, Japanese release, English release">
+    <title>All Trails Games in Order of Release - Zemurian Atlas</title>
+    <meta name="description" content="A complete list of all Trails (Kiseki) series games in order of release, from original Japanese releases to worldwide localizations. Track every title from 2004 to upcoming releases.">
+    <meta name="keywords" content="all trails games, trails games in order, trails series release order, Trails of Cold Steel, Trails in the Sky, Trails from Zero, Trails to Azure, Trails into Reverie, release dates, localization, Japanese release, English release">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://jun-eau.github.io/zemurian-atlas/games.html">
-    <meta property="og:title" content="Trails/Kiseki Series Release Timeline - Zemurian Atlas">
-    <meta property="og:description" content="A complete timeline of all Trails (Kiseki) series games, from original Japanese releases to worldwide localizations. Track every title from 2004 to upcoming releases.">
+    <meta property="og:title" content="All Trails Games in Order of Release - Zemurian Atlas">
+    <meta property="og:description" content="A complete list of all Trails (Kiseki) series games in order of release, from original Japanese releases to worldwide localizations.">
     <meta property="og:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://jun-eau.github.io/zemurian-atlas/games.html">
-    <meta property="twitter:title" content="Trails/Kiseki Series Release Timeline - Zemurian Atlas">
-    <meta property="twitter:description" content="A complete timeline of all Trails (Kiseki) series games, from original Japanese releases to worldwide localizations. Track every title from 2004 to upcoming releases.">
+    <meta property="twitter:title" content="All Trails Games in Order of Release - Zemurian Atlas">
+    <meta property="twitter:description" content="A complete list of all Trails (Kiseki) series games in order of release, from original Japanese releases to worldwide localizations.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
     <link rel="stylesheet" href="src/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -3,22 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Zemurian Atlas: An Interactive Trails/Kiseki Series Timeline</title>
-    <meta name="description" content="Journey through the history and lore of the Trails (Kiseki) series with our interactive timeline and visual guide. Explore release dates, in-game chronology, and the world of Zemuria.">
-    <meta name="keywords" content="Trails series, Kiseki series, JRPG, timeline, lore, chronology, Falcom, Zemuria, Liberl, Crossbell, Erebonia, Calvard">
+    <title>Zemurian Atlas: Trails Series Map, Timeline, and Games</title>
+    <meta name="description" content="A visual guide to the Trails (Kiseki) series, featuring an interactive map of Zemuria, a complete game release timeline, and a detailed in-game chronological timeline.">
+    <meta name="keywords" content="Trails series, Kiseki series, JRPG, timeline, lore, chronology, Falcom, Zemuria, Liberl, Crossbell, Erebonia, Calvard, all trails games, trails series map, trails series timeline">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://jun-eau.github.io/zemurian-atlas/">
-    <meta property="og:title" content="Zemurian Atlas: An Interactive Trails/Kiseki Series Timeline">
-    <meta property="og:description" content="Journey through the history and lore of the Trails (Kiseki) series with our interactive timeline and visual guide. Explore release dates, in-game chronology, and the world of Zemuria.">
+    <meta property="og:title" content="Zemurian Atlas: Trails Series Map, Timeline, and Games">
+    <meta property="og:description" content="A visual guide to the Trails (Kiseki) series, featuring an interactive map of Zemuria, a complete game release timeline, and a detailed in-game chronological timeline.">
     <meta property="og:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://jun-eau.github.io/zemurian-atlas/">
-    <meta property="twitter:title" content="Zemurian Atlas: An Interactive Trails/Kiseki Series Timeline">
-    <meta property="twitter:description" content="Journey through the history and lore of the Trails (Kiseki) series with our interactive timeline and visual guide. Explore release dates, in-game chronology, and the world of Zemuria.">
+    <meta property="twitter:title" content="Zemurian Atlas: Trails Series Map, Timeline, and Games">
+    <meta property="twitter:description" content="A visual guide to the Trails (Kiseki) series, featuring an interactive map of Zemuria, a complete game release timeline, and a detailed in-game chronological timeline.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
     <link rel="stylesheet" href="src/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/map.html
+++ b/map.html
@@ -3,22 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Interactive Map of Zemuria - Trails/Kiseki Series | Zemurian Atlas</title>
-    <meta name="description" content="Explore the continent of Zemuria with an interactive map. Discover the locations and key regions from the Trails (Kiseki) series, including Liberl, Crossbell, Erebonia, and Calvard.">
-    <meta name="keywords" content="Zemuria map, Trails series map, Kiseki map, interactive map, Liberl, Crossbell, Erebonia, Calvard">
+    <title>Interactive Trails Series Map of Zemuria - Zemurian Atlas</title>
+    <meta name="description" content="Explore the continent of Zemuria with our interactive Trails series map. Discover the locations and key regions from the Trails (Kiseki) games, including Liberl, Crossbell, Erebonia, and Calvard.">
+    <meta name="keywords" content="trails series map, zemuria map, kiseki map, interactive map, trails map, Liberl, Crossbell, Erebonia, Calvard">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://jun-eau.github.io/zemurian-atlas/map.html">
-    <meta property="og:title" content="Interactive Map of Zemuria - Trails/Kiseki Series | Zemurian Atlas">
-    <meta property="og:description" content="Explore the continent of Zemuria with an interactive map. Discover the locations and key regions from the Trails (Kiseki) series.">
+    <meta property="og:title" content="Interactive Trails Series Map of Zemuria - Zemurian Atlas">
+    <meta property="og:description" content="Explore the continent of Zemuria with our interactive Trails series map. Discover the locations and key regions from the Trails (Kiseki) games.">
     <meta property="og:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://jun-eau.github.io/zemurian-atlas/map.html">
-    <meta property="twitter:title" content="Interactive Map of Zemuria - Trails/Kiseki Series | Zemurian Atlas">
-    <meta property="twitter:description" content="Explore the continent of Zemuria with an interactive map. Discover the locations and key regions from the Trails (Kiseki) series.">
+    <meta property="twitter:title" content="Interactive Trails Series Map of Zemuria - Zemurian Atlas">
+    <meta property="twitter:description" content="Explore the continent of Zemuria with our interactive Trails series map. Discover the locations and key regions from the Trails (Kiseki) games.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
     <link rel="stylesheet" href="src/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/timeline.html
+++ b/timeline.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Trails/Kiseki Series Lore Timeline - Zemurian Atlas</title>
+    <title>Trails Series Timeline of Events - Zemurian Atlas</title>
     <meta name="description" content="Explore the rich history and in-game chronology of the Trails (Kiseki) series with a detailed timeline of events in Zemuria.">
-    <meta name="keywords" content="Trails series lore, Kiseki lore, timeline of Zemurian history, in-game chronology, Liberl, Crossbell, Erebonia, Calvard">
+    <meta name="keywords" content="trails series timeline, kiseki series timeline, timeline of zemurian history, in-game chronology, trails lore, Liberl, Crossbell, Erebonia, Calvard">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://jun-eau.github.io/zemurian-atlas/timeline.html">
-    <meta property="og:title" content="Trails/Kiseki Series Lore Timeline - Zemurian Atlas">
+    <meta property="og:title" content="Trails Series Timeline of Events - Zemurian Atlas">
     <meta property="og:description" content="Explore the rich history and in-game chronology of the Trails (Kiseki) series with a detailed timeline of events in Zemuria.">
     <meta property="og:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://jun-eau.github.io/zemurian-atlas/timeline.html">
-    <meta property="twitter:title" content="Trails/Kiseki Series Lore Timeline - Zemurian Atlas">
+    <meta property="twitter:title" content="Trails Series Timeline of Events - Zemurian Atlas">
     <meta property="twitter:description" content="Explore the rich history and in-game chronology of the Trails (Kiseki) series with a detailed timeline of events in Zemuria.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
     <link rel="stylesheet" href="src/css/style.css">


### PR DESCRIPTION
Revises the page titles and meta descriptions for all HTML pages to better target common search queries like "trails series map," "trails series timeline," and "all trails games."

- Updates `index.html` to have a more comprehensive title and description.
- Updates `games.html` to target "all trails games" search query.
- Updates `map.html` to target "trails series map" and "zemuria map" search queries.
- Updates `timeline.html` to target "trails series timeline" search query.