### PR TITLE
feat: Remove horizontal expansion limit on timeline

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -476,7 +476,6 @@ body.home-page::before {
 =================================================================
 */
 .main-lore {
-    max-width: 1600px;
 }
 
 /* 6.1. Timeline */
@@ -544,7 +543,7 @@ body.home-page::before {
     background-color: rgba(153, 153, 185, 0.3);
 }
 .timeline-arc-column {
-    flex: 1 1 0px;
+    flex: 0 0 400px;
     padding: 0 15px;
     border-right: 1px dashed rgba(153, 153, 185, 0.3);
     box-sizing: border-box;


### PR DESCRIPTION
Removes the `max-width` restriction on the timeline's main container (`.main-lore`), allowing it to expand horizontally.

To ensure the timeline elements remain static and do not stretch with the container, the flex properties of the timeline columns (`.timeline-arc-column`) have been adjusted. Their `flex` property is set to `0 0 400px`, giving them a fixed width and preventing them from growing or shrinking.

This change makes the timeline view horizontally expandable while keeping the content within it at a static width, with a horizontal scrollbar appearing on narrower viewports as intended.