### PR TITLE
feat: Implement mobile-first interactive map

### DIFF
--- a/map.html
+++ b/map.html
@@ -31,6 +31,8 @@
     </script>
 
     <link rel="stylesheet" href="src/css/style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
@@ -81,6 +83,7 @@
                     </svg>
                 </div>
             </div>
+            <div id="mobile-map-container"></div>
 
             <!-- Static Infobox Structure -->
             <div id="map-infobox-1" class="map-infobox">
@@ -108,5 +111,13 @@
         </p>
     </footer>
 
+    <div id="mobile-info-panel" class="mobile-info-panel">
+        <div class="panel-header">
+            <h3 class="panel-title"></h3>
+            <button class="close-panel-btn">×</button>
+        </div>
+        <div class="panel-content">
+        </div>
+    </div>
 </body>
 </html>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1114,6 +1114,79 @@ body.home-page::before {
         font-size: var(--font-size-sm);
         max-width: 90%;
     }
+
+    /* 7.5. Mobile Interactive Map */
+    .full-width-section {
+        display: none;
+    }
+    #mobile-map-container {
+        /* Header is 114px high on mobile */
+        height: calc(100vh - 114px);
+        width: 100%;
+        background-color: #1a1a1a;
+    }
+    .mobile-info-panel {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 40vh;
+        background-color: var(--primary-bg);
+        border-top: 2px solid var(--accent-gold);
+        box-shadow: 0 -5px 20px rgba(0,0,0,0.4);
+        transform: translateY(100%);
+        transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+        z-index: 1100; /* Above leaflet controls */
+        display: flex;
+        flex-direction: column;
+    }
+    .mobile-info-panel.active {
+        transform: translateY(0);
+    }
+    .panel-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.5rem 1rem;
+        background-color: #2a2a2a;
+        border-bottom: 1px solid #444;
+    }
+    .panel-title {
+        margin: 0;
+        font-family: 'Playfair Display', serif;
+        font-size: var(--font-size-lg);
+        color: var(--accent-gold);
+    }
+    .close-panel-btn {
+        background: none;
+        border: none;
+        color: var(--text-secondary);
+        font-size: var(--font-size-xl);
+        cursor: pointer;
+        padding: 0.25rem 0.5rem;
+        line-height: 1;
+    }
+    .close-panel-btn:hover {
+        color: var(--text-primary);
+    }
+    .panel-content {
+        padding: 1rem;
+        overflow-y: auto;
+        flex-grow: 1;
+        font-size: var(--font-size-sm);
+        line-height: var(--line-height-relaxed);
+    }
+    .panel-content h4 {
+        color: var(--accent-gold);
+        border-bottom: 1px solid rgba(233, 213, 161, 0.3);
+        padding-bottom: 0.25rem;
+        margin-top: 0;
+        margin-bottom: 0.5rem;
+    }
+    .panel-content p {
+        margin-top: 0;
+        margin-bottom: 1rem;
+    }
 }
 
 /* --- Initial Hiding of Mobile/Desktop Specific Elements --- */

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -1,31 +1,133 @@
 import { calculateRegionAreaInSelge } from './lib/geometry.js';
 
-export function initMapPage() {
-    let isMapInitialized = false;
-    let infobox1, infobox2, currentInfobox; // Variables for the two infobox elements and state tracking
+// --- SHARED DATA ---
+let mapRegionsData = [];
+let mapGamesData = [];
 
-    // --- Map Logic & Data ---
-    let mapRegionsData = [];
-    let mapGamesData = [];
+// --- ENTRY POINT ---
+export function initMapPage() {
+    const mapContainer = document.querySelector('.map-container');
+    if (mapContainer) {
+        mapContainer.classList.add('is-loading');
+    }
+
+    Promise.all([
+        fetch('src/data/regions.json').then(res => res.ok ? res.json() : Promise.reject(res.status)),
+        fetch('src/data/games.json').then(res => res.ok ? res.json() : Promise.reject(res.status))
+    ])
+    .then(([regions, games]) => {
+        mapGamesData = games;
+        mapRegionsData = regions.map(region => ({
+            ...region,
+            formattedArea: calculateRegionAreaInSelge(region)
+        }));
+
+        if (mapContainer) {
+            mapContainer.classList.remove('is-loading');
+        }
+
+        if (window.innerWidth <= 900 && typeof L !== 'undefined') {
+            initMobileMap();
+        } else {
+            initDesktopMap();
+        }
+    })
+    .catch(error => {
+        console.error("Error loading map/game data:", error);
+        if (mapContainer) {
+            mapContainer.classList.remove('is-loading');
+        }
+    });
+}
+
+// --- MOBILE MAP IMPLEMENTATION (FINAL REFACTOR) ---
+function initMobileMap() {
+    const mapContainer = document.getElementById('mobile-map-container');
+    const infoPanel = document.getElementById('mobile-info-panel');
+    const panelTitle = infoPanel.querySelector('.panel-title');
+    const panelContent = infoPanel.querySelector('.panel-content');
+    const closeBtn = infoPanel.querySelector('.close-panel-btn');
+
+    if (!mapContainer || !infoPanel) return;
+
+    const bounds = [[0, 0], [1744, 2800]];
+    const map = L.map('mobile-map-container', {
+        crs: L.CRS.Simple,
+        minZoom: -2,
+        attributionControl: false
+    });
+
+    L.imageOverlay('assets/zemuria-map.webp', bounds).addTo(map);
+
+    // 1. Create a single SVG element that will contain all region paths.
+    const svgElement = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svgElement.setAttribute('xmlns', "http://www.w3.org/2000/svg");
+    svgElement.setAttribute('viewBox', '0 0 2800 1744');
+
+    // 2. Loop through regions and add each as a <path> to the SVG element.
+    mapRegionsData.forEach(region => {
+        const path = document.createElementNS("http://www.w3.org/2000/svg", 'path');
+        path.setAttribute('d', region.svgPathData);
+
+        // Style the path
+        path.setAttribute('fill', region.baseColor || '#FFFFFF');
+        path.setAttribute('fill-opacity', '0.2');
+        path.setAttribute('stroke', region.baseColor || '#FFFFFF');
+        path.setAttribute('stroke-width', '5');
+        path.setAttribute('stroke-opacity', '0.7');
+        path.style.cursor = 'pointer';
+        path.style.transition = 'fill-opacity 0.2s ease-in-out';
+
+        // Add event listeners directly to each path
+        path.addEventListener('mouseover', () => path.setAttribute('fill-opacity', '0.4'));
+        path.addEventListener('mouseout', () => path.setAttribute('fill-opacity', '0.2'));
+        path.addEventListener('click', () => {
+            panelTitle.textContent = region.name;
+            panelContent.innerHTML = `
+                <h4>Description</h4>
+                <p>${region.description || 'No description available.'}</p>
+                <h4>History</h4>
+                <p>${region.history || 'No history available.'}</p>
+                ${region.capital ? `<h4>Capital</h4><p>${region.capital}</p>` : ''}
+            `;
+            infoPanel.classList.add('active');
+        });
+
+        svgElement.appendChild(path);
+    });
+
+    // 3. Create a single SVG overlay with the complete SVG element.
+    L.svgOverlay(svgElement, bounds, { interactive: true }).addTo(map);
+
+    closeBtn.addEventListener('click', () => {
+        infoPanel.classList.remove('active');
+    });
+
+    map.fitBounds(bounds);
+    map.setMinZoom(map.getZoom());
+    map.setMaxZoom(map.getZoom() + 3);
+}
+
+
+// --- DESKTOP MAP IMPLEMENTATION ---
+function initDesktopMap() {
+    let isMapInitialized = false;
+    let infobox1, infobox2, currentInfobox;
 
     function initializeMap() {
         if (isMapInitialized) return;
         isMapInitialized = true;
 
         const svgNS = "http://www.w3.org/2000/svg";
-        const mapContainer = document.querySelector('.map-container');
         const mapOverlay = document.getElementById('map-overlay');
-        // Assign to the variables declared in the higher scope
         infobox1 = document.getElementById('map-infobox-1');
         infobox2 = document.getElementById('map-infobox-2');
         currentInfobox = infobox1;
 
-        if (!mapContainer || !mapOverlay || !infobox1 || !infobox2) {
-            console.error("Required map elements not found!");
+        if (!mapOverlay || !infobox1 || !infobox2) {
+            console.error("Required desktop map elements not found!");
             return;
         }
-
-        mapContainer.classList.add('is-loading');
 
         function hexToRgba(hex, alpha = 1) {
             hex = hex.replace(/^#/, '');
@@ -36,70 +138,38 @@ export function initMapPage() {
             return `rgba(${r}, ${g}, ${b}, ${alpha})`;
         }
 
-        Promise.all([
-            fetch('src/data/regions.json').then(res => res.ok ? res.json() : Promise.reject(res.status)),
-            fetch('src/data/games.json').then(res => res.ok ? res.json() : Promise.reject(res.status))
-        ])
-        .then(([regions, games]) => {
-            // Now that data is loaded, assign it and calculate areas
-            mapGamesData = games;
-            mapRegionsData = regions.map(region => ({
-                ...region,
-                formattedArea: calculateRegionAreaInSelge(region)
-            }));
+        const maskGroup = mapOverlay.querySelector('#regions-mask g');
+        if (!maskGroup) return;
 
-            // Create the SVG paths for regions and the mask
-            const maskGroup = mapOverlay.querySelector('#regions-mask g');
-            if (!maskGroup) return;
+        mapRegionsData.forEach(region => {
+            const path = document.createElementNS(svgNS, 'path');
+            path.setAttribute('d', region.svgPathData);
+            path.setAttribute('class', 'region-path');
+            path.id = `region-${region.id}`;
+            path.dataset.regionId = region.id;
+            if (region.baseColor) {
+                path.style.setProperty('--region-highlight-color', hexToRgba(region.baseColor, 0.4));
+            }
+            mapOverlay.appendChild(path);
 
-            mapRegionsData.forEach(region => {
-                const path = document.createElementNS(svgNS, 'path');
-                path.setAttribute('d', region.svgPathData);
-                path.setAttribute('class', 'region-path');
-                path.id = `region-${region.id}`;
-                path.dataset.regionId = region.id;
-                if (region.baseColor) {
-                    path.style.setProperty('--region-highlight-color', hexToRgba(region.baseColor, 0.4));
-                }
-                mapOverlay.appendChild(path);
+            const maskPath = document.createElementNS(svgNS, 'path');
+            maskPath.setAttribute('d', region.svgPathData);
+            maskPath.setAttribute('fill', 'black');
+            maskGroup.appendChild(maskPath);
+        });
 
-                const maskPath = document.createElementNS(svgNS, 'path');
-                maskPath.setAttribute('d', region.svgPathData);
-                maskPath.setAttribute('fill', 'black');
-                maskGroup.appendChild(maskPath);
-            });
-
-            // ATTACH THE EVENT LISTENER - only after data is ready and paths are drawn
-            mapOverlay.addEventListener('click', (e) => {
-                const clickedPath = e.target.closest('.region-path');
-                const clickedRegionId = clickedPath ? clickedPath.dataset.regionId : null;
-
-                handleMapClick(clickedRegionId, e.clientX, e.clientY, e.pageX, e.pageY);
-            });
-
-            // Remove the loading state
-            mapContainer.classList.remove('is-loading');
-        })
-        .catch(error => {
-            console.error("Error loading map/game data:", error);
-            mapContainer.classList.remove('is-loading');
+        mapOverlay.addEventListener('click', (e) => {
+            const clickedPath = e.target.closest('.region-path');
+            const clickedRegionId = clickedPath ? clickedPath.dataset.regionId : null;
+            handleMapClick(clickedRegionId, e.clientX, e.clientY, e.pageX, e.pageY);
         });
     }
 
-    /**
-     * Handles clicks on the map overlay. Assumes mapRegionsData and mapGamesData are populated.
-     * @param {string|null} clickedRegionId The ID of the clicked region, or null.
-     * @param {number} clientX The clientX of the click event.
-     * @param {number} clientY The clientY of the click event.
-     * @param {number} pageX The pageX of the click event.
-     * @param {number} pageY The pageY of the click event.
-     */
     function handleMapClick(clickedRegionId, clientX, clientY, pageX, pageY) {
         const outgoingBox = currentInfobox;
         const isInfoboxActive = outgoingBox.classList.contains('active');
         const currentRegionId = outgoingBox.dataset.regionId;
 
-        // Case 1: Close the active infobox if clicking outside or on the same region
         if (!clickedRegionId || (isInfoboxActive && clickedRegionId === currentRegionId)) {
             if (isInfoboxActive) {
                 outgoingBox.classList.remove('active');
@@ -111,31 +181,17 @@ export function initMapPage() {
         const region = mapRegionsData.find(r => r.id === clickedRegionId);
         if (!region) return;
 
-        // Determine which box will be the new one
         const incomingBox = (outgoingBox.id === 'map-infobox-1') ? infobox2 : infobox1;
-
-        // Make sure the incoming box is ready to be displayed (it might be display:none from a previous close)
         incomingBox.style.display = 'block';
-
-        // Populate the incoming box with new content
         updateInfoboxContents(region, incomingBox);
 
-        // Prepare the incoming box (size and position it), and once it's ready, trigger the animation
         prepareAndPositionInfobox(region, incomingBox, clientX, clientY, pageX, pageY).then(() => {
-            // Now, trigger the cross-fade
             outgoingBox.classList.remove('active');
             incomingBox.classList.add('active');
-
-            // Update the state to track the new active box
             currentInfobox = incomingBox;
         });
     }
 
-    /**
-     * Populates the infobox with content for a given region.
-     * @param {object} region The region data object.
-     * @param {HTMLElement} infoboxEl The main infobox element.
-     */
     function updateInfoboxContents(region, infoboxEl) {
         const headerEl = infoboxEl.querySelector('.map-infobox-header');
         const gamesViewEl = infoboxEl.querySelector('.infobox-games-view');
@@ -143,18 +199,9 @@ export function initMapPage() {
         const footerEl = infoboxEl.querySelector('.map-infobox-footer');
         const bodyEl = infoboxEl.querySelector('.infobox-body');
 
-        // Populate Header
         const hasEmblem = region.emblemAsset;
-        if (hasEmblem) {
-            headerEl.style.gridTemplateColumns = '40px 1fr auto';
-        } else {
-            headerEl.style.gridTemplateColumns = '1fr auto';
-        }
-
-        let headerHTML = '';
-        if (hasEmblem) {
-            headerHTML += `<img src="assets/logo/${region.emblemAsset}" alt="${region.name} Emblem" class="map-infobox-emblem">`;
-        }
+        headerEl.style.gridTemplateColumns = hasEmblem ? '40px 1fr auto' : '1fr auto';
+        let headerHTML = hasEmblem ? `<img src="assets/logo/${region.emblemAsset}" alt="${region.name} Emblem" class="map-infobox-emblem">` : '';
         headerHTML += `
             <div class="map-infobox-title-section">
                 <h3>${region.name}</h3>
@@ -164,16 +211,13 @@ export function initMapPage() {
                 <a href="${region.falcomWikiUrl}" target="_blank" rel="noopener noreferrer" title="View on Falcom Wiki">
                     <img src="assets/logo/falcom-wiki.png" alt="Falcom Wiki">
                 </a>
-            </div>
-        `;
+            </div>`;
         headerEl.innerHTML = headerHTML;
 
-        // Populate Games View
         const gamesInRegion = mapGamesData.filter(game => (region.games || []).includes(game.id));
         gamesViewEl.innerHTML = gamesInRegion.length > 0
             ? `<div class="map-infobox-games-grid">${gamesInRegion.map(game => {
                 let assetName = game.assetName;
-                // Per user request, show the 1st Chapter variant grid art for the Liberl infobox.
                 if (game.id === 'trails-in-the-sky' && game.variants && game.variants.length > 0) {
                     assetName = game.variants[0].assetName;
                 }
@@ -181,7 +225,6 @@ export function initMapPage() {
               }).join('')}</div>`
             : '<p style="font-size: 0.8em; color: #999;">No specific games are primarily set in this region.</p>';
 
-        // Populate Lore View
         const featuredInGames = mapGamesData.filter(game => (region.featuredIn || []).includes(game.id));
         let featuredInHtml = featuredInGames.length > 0 ? `
             <div class="map-infobox-lore-section">
@@ -202,20 +245,15 @@ export function initMapPage() {
                 <h4 style="color: ${region.baseColor}; border-bottom-color: ${region.baseColor};">History</h4>
                 <p>${region.history}</p>
             </div>
-            ${featuredInHtml}
-        `;
+            ${featuredInHtml}`;
 
-        // Set initial view state first, so the button text is correct.
         const showLoreInitially = region.regionType !== 'major';
         infoboxEl.classList.toggle('show-lore-view', showLoreInitially);
-
-        // Populate Footer & Set Up Toggle
         footerEl.innerHTML = '';
         if (region.regionType === 'major') {
             footerEl.style.display = 'block';
             const toggleButton = document.createElement('button');
             toggleButton.className = 'map-infobox-toggle-btn';
-
             const updateButtonText = () => {
                 toggleButton.textContent = infoboxEl.classList.contains('show-lore-view') ? 'Show Game Art' : 'Show More Details';
             };
@@ -226,31 +264,19 @@ export function initMapPage() {
                 const targetView = infoboxEl.classList.contains('show-lore-view') ? loreViewEl : gamesViewEl;
                 bodyEl.style.height = `${targetView.scrollHeight}px`;
             });
-
             footerEl.appendChild(toggleButton);
-            updateButtonText(); // Now this will be correct.
+            updateButtonText();
         } else {
             footerEl.style.display = 'none';
         }
     }
 
-    /**
-     * Sizes, positions, and prepares the infobox, returning a promise that resolves when ready.
-     * @param {object} region The region data object.
-     * @param {HTMLElement} infoboxEl The main infobox element.
-     * @param {number} clientX The clientX of the click event for viewport boundary checks.
-     * @param {number} clientY The clientY of the click event for viewport boundary checks.
-     * @param {number} pageX The pageX of the click event for document-relative positioning.
-     * @param {number} pageY The pageY of the click event for document-relative positioning.
-     * @returns {Promise} A promise that resolves when the infobox is sized and positioned.
-     */
     function prepareAndPositionInfobox(region, infoboxEl, clientX, clientY, pageX, pageY) {
         const bodyEl = infoboxEl.querySelector('.infobox-body');
         const gamesViewEl = infoboxEl.querySelector('.infobox-games-view');
         const loreViewEl = infoboxEl.querySelector('.infobox-lore-view');
         const gamesInRegion = mapGamesData.filter(game => (region.games || []).includes(game.id));
 
-        // Set width before calculating height
         if (region.regionType === 'major' && gamesInRegion.length > 0) {
             const gridWidth = (gamesInRegion.length * 80) + ((gamesInRegion.length - 1) * 8);
             infoboxEl.style.width = `${gridWidth + 24}px`;
@@ -258,44 +284,27 @@ export function initMapPage() {
             infoboxEl.style.width = '320px';
         }
 
-        // --- Image and Font Loading Fix ---
         const images = gamesViewEl.querySelectorAll('img');
         const imageLoadPromises = [...images].map(img => {
             if (img.complete) return Promise.resolve();
             return new Promise((resolve) => {
                 img.onload = resolve;
-                img.onerror = resolve; // Resolve on error too so it doesn't hang forever
+                img.onerror = resolve;
             });
         });
 
         return Promise.all([document.fonts.ready, ...imageLoadPromises]).then(() => {
-            // The 'show-lore-view' class is now set in updateInfoboxContents.
-            // We just need to read it here to determine the initial view for height calculation.
             const initialView = infoboxEl.classList.contains('show-lore-view') ? loreViewEl : gamesViewEl;
-
-            // --- Height Calculation & Transition Fix ---
-            // 1. Add a class to disable transitions on the body.
             bodyEl.classList.add('no-transition');
-            // 2. Set the height instantaneously.
             bodyEl.style.height = `${initialView.scrollHeight}px`;
-
-            // 3. Force a reflow. Accessing offsetHeight is a common way to do this.
-            // This ensures the browser applies the height change before we re-enable transitions.
             void bodyEl.offsetHeight;
-
-            // 4. Remove the no-transition class so future toggles are animated.
             bodyEl.classList.remove('no-transition');
 
-
-            // Position the infobox
             const rect = infoboxEl.getBoundingClientRect();
             const offsetX = 20, offsetY = 20;
-
-            // Use pageX/pageY for the base position, making it relative to the document
             let top = pageY + offsetY;
             let left = pageX + offsetX;
 
-            // Use clientX/clientY for viewport boundary checks to decide if we need to flip
             if (clientX + offsetX + rect.width > window.innerWidth) {
                 left = pageX - rect.width - offsetX;
             }
@@ -305,8 +314,6 @@ export function initMapPage() {
 
             infoboxEl.style.left = `${Math.max(5, left)}px`;
             infoboxEl.style.top = `${Math.max(5, top)}px`;
-
-            // Set dataset for identification
             infoboxEl.dataset.regionId = region.id;
         });
     }


### PR DESCRIPTION
This commit introduces a new, mobile-first interactive map experience for the Zemurian Atlas, powered by Leaflet.js.

The implementation is designed for screens up to 900px wide and is self-contained to avoid conflicts with the existing desktop map.

Key changes:
- `map.html` is updated to include a new `#mobile-map-container` and a `#mobile-info-panel` for displaying region details. The Leaflet.js library is now included via CDN.
- `src/css/style.css` contains new responsive styles to create the full-screen mobile map layout, hide the desktop version on mobile, and style the new interactive elements, including the slide-up animation for the info panel.
- `src/js/map.js` is refactored to detect the screen width and initialize the appropriate map. The new mobile logic uses Leaflet.js to render the map, overlays interactive SVG paths for each region, and handles tap events to display region information in the panel.