### PR TITLE
feat(map): Implement enhanced mobile-first interactive map

### DIFF
--- a/map.html
+++ b/map.html
@@ -83,7 +83,9 @@
                     </svg>
                 </div>
             </div>
-            <div id="mobile-map-container"></div>
+            <div id="mobile-map-container">
+                <div class="map-dim-overlay"></div>
+            </div>
 
             <!-- Static Infobox Structure -->
             <div id="map-infobox-1" class="map-infobox">
@@ -117,6 +119,18 @@
             <button class="close-panel-btn">×</button>
         </div>
         <div class="panel-content">
+            <div class="panel-tabs">
+                <button class="panel-tab active" data-tab="lore">Lore</button>
+                <button class="panel-tab" data-tab="games">Games</button>
+            </div>
+            <div class="panel-tab-content">
+                <div id="panel-lore-content" class="panel-content-pane active">
+                    <!-- Lore content injected by JS -->
+                </div>
+                <div id="panel-games-content" class="panel-content-pane">
+                    <!-- Games content injected by JS -->
+                </div>
+            </div>
         </div>
     </div>
 </body>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -872,6 +872,10 @@ body.home-page::before {
 */
 /* 7.1. General Mobile Layout */
 @media (max-width: 900px) {
+    body {
+        overflow: hidden; /* Prevent scrolling on the page itself */
+    }
+
     main {
         min-width: 0 !important;
         width: auto;
@@ -881,6 +885,10 @@ body.home-page::before {
         margin-right: 0;
         box-sizing: border-box;
         overflow-x: hidden; /* Contain horizontal overflow from children like sliders */
+    }
+
+    footer {
+        display: none; /* Hide footer on mobile */
     }
 
     /* Fix for mobile scroll and shadow clipping issues */
@@ -1170,12 +1178,13 @@ body.home-page::before {
         color: var(--text-primary);
     }
     .panel-content {
-        padding: 1rem;
-        overflow-y: auto;
+        padding: 0;
+        overflow-y: hidden;
         flex-grow: 1;
-        font-size: var(--font-size-sm);
-        line-height: var(--line-height-relaxed);
+        display: flex; /* Allow content to grow */
+        flex-direction: column;
     }
+
     .panel-content h4 {
         color: var(--accent-gold);
         border-bottom: 1px solid rgba(233, 213, 161, 0.3);
@@ -1183,9 +1192,87 @@ body.home-page::before {
         margin-top: 0;
         margin-bottom: 0.5rem;
     }
+
     .panel-content p {
         margin-top: 0;
         margin-bottom: 1rem;
+    }
+
+    /* --- New Mobile Map Interaction Styles --- */
+    #mobile-map-container .leaflet-overlay-pane svg path {
+        fill-opacity: 0;
+        stroke-opacity: 0;
+        transition: fill-opacity 0.3s ease, stroke-opacity 0.3s ease;
+    }
+
+    #mobile-map-container .leaflet-overlay-pane svg path.highlighted {
+        fill-opacity: 0.4;
+        stroke-opacity: 0.9;
+    }
+
+    .map-dim-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.6);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease-in-out;
+        z-index: 10; /* Above map image, below svg */
+    }
+
+    .map-dim-overlay.active {
+        opacity: 1;
+    }
+
+    /* --- New Info Panel Tab Styles --- */
+    .panel-tabs {
+        display: flex;
+        flex-shrink: 0;
+        background-color: #2a2a2a;
+    }
+    .panel-tab {
+        flex: 1;
+        padding: 0.75rem;
+        background: none;
+        border: none;
+        border-bottom: 3px solid transparent;
+        color: var(--text-secondary);
+        font-size: var(--font-size-base);
+        font-weight: 600;
+        cursor: pointer;
+        transition: color 0.2s, border-color 0.2s;
+    }
+    .panel-tab:hover {
+        color: var(--text-primary);
+    }
+    .panel-tab.active {
+        color: var(--accent-gold);
+        border-bottom-color: var(--accent-gold);
+    }
+
+    .panel-tab-content {
+        flex-grow: 1;
+        overflow-y: auto;
+    }
+
+    .panel-content-pane {
+        display: none;
+        padding: 1rem;
+    }
+    .panel-content-pane.active {
+        display: block;
+    }
+    .panel-games-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+        gap: 10px;
+    }
+    .panel-games-grid img {
+        width: 100%;
+        border-radius: 4px;
     }
 }
 


### PR DESCRIPTION
This commit introduces a new, mobile-first interactive map experience for the Zemurian Atlas, powered by Leaflet.js, and includes significant UX enhancements based on user feedback.

The implementation is designed for screens up to 900px wide and is self-contained to avoid conflicts with the existing desktop map.

The following changes have been made:
- `map.html` was updated with a container for the mobile map, a dimming overlay, and a new tabbed structure for the info panel.
- `src/css/style.css` now includes responsive styles for the immersive mobile layout, the new selection/dimming effects, and the tabbed panel. The footer is hidden and body scrolling is disabled on mobile.
- `src/js/map.js` was refactored to handle the new interactions. The `initMobileMap` function now creates a single SVG overlay for all regions, manages the highlight/dimming effects, and populates the new tabbed info panel with both lore and game data.