### PR TITLE
feat(map): Implement enhanced mobile-first interactive map

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1263,7 +1263,7 @@ body.home-page::before {
     }
     .panel-tab {
         flex: 1;
-        padding: 0.75rem;
+        padding: 0.5rem;
         background: none;
         border: none;
         border-bottom: 3px solid transparent;

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -151,10 +151,11 @@ function initMobileMap() {
         const hasGames = region.games && region.games.length > 0;
         const featuredInGames = mapGamesData.filter(game => (region.featuredIn || []).includes(game.id));
         let featuredInHtml = '';
-        if (!hasGames && featuredInGames.length > 0) {
+        if (featuredInGames.length > 0) {
+            const title = hasGames ? "Also Featured In" : "Featured In";
             featuredInHtml = `
                 <div class="panel-lore-section">
-                    <h4 style="color: ${region.baseColor}; border-bottom-color: ${region.baseColor};">Featured In</h4>
+                    <h4 style="color: ${region.baseColor}; border-bottom-color: ${region.baseColor};">${title}</h4>
                     <ul>${featuredInGames.map(game => `<li>${game.englishTitle}</li>`).join('')}</ul>
                 </div>`;
         }


### PR DESCRIPTION
This commit introduces a new, mobile-first interactive map experience for the Zemurian Atlas, powered by Leaflet.js, and includes significant UX enhancements to achieve feature parity with the desktop version.

The implementation is designed for screens up to 900px wide and is self-contained to avoid conflicts with the existing desktop map.

The following changes have been made:
- `map.html` was updated to support a fully dynamic info panel, with the header and tabs now generated by JavaScript.
- `src/css/style.css` now includes responsive styles for the immersive mobile layout, the new selection/dimming effects, a more complex panel header, an increased panel height of 55vh, and reduced padding on the panel tabs for a shorter height. The `overflow: hidden` property is now scoped to a `.no-scroll` class to prevent global scroll locking.
- `src/js/map.js` was significantly refactored. The `initMobileMap` function now dynamically builds the entire info panel—including the header and conditional tabs—based on the selected region's data. It correctly displays the "Also Featured In" section for all relevant regions. It also adds the `.no-scroll` class to the body to disable scrolling only on the mobile map page. Hover effects have been removed for a cleaner touch experience.