### PR TITLE
Implement mobile map UX enhancements

### DIFF
--- a/map.html
+++ b/map.html
@@ -84,6 +84,7 @@
                 </div>
             </div>
             <div id="mobile-map-container">
+                <div id="mobile-map-instruction">Tap a region to explore <button>&times;</button></div>
                 <div class="map-dim-overlay"></div>
             </div>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -865,6 +865,18 @@ body.home-page::before {
     transition-delay: 0s;
 }
 
+@keyframes pulse {
+    0% {
+        stroke-opacity: 0.9;
+    }
+    50% {
+        stroke-opacity: 0.5;
+    }
+    100% {
+        stroke-opacity: 0.9;
+    }
+}
+
 /*
 =================================================================
 7. Responsive Styles (Mobile)
@@ -1124,6 +1136,35 @@ body.home-page::before {
     }
 
     /* 7.5. Mobile Interactive Map */
+    #mobile-map-instruction {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        background: rgba(0, 0, 0, 0.6);
+        color: var(--text-primary);
+        text-align: center;
+        padding: 8px;
+        font-size: var(--font-size-sm);
+        z-index: 1001; /* Above map, below header */
+        transition: transform 0.3s ease-in-out;
+    }
+    #mobile-map-instruction.hidden {
+        transform: translateY(-100%);
+    }
+    #mobile-map-instruction button {
+        background: none;
+        border: none;
+        color: var(--text-primary);
+        font-size: 1.2rem;
+        margin-left: 10px;
+        cursor: pointer;
+        opacity: 0.7;
+        padding: 0 5px;
+    }
+    #mobile-map-instruction button:hover {
+        opacity: 1;
+    }
     .full-width-section {
         display: none;
     }
@@ -1195,11 +1236,13 @@ body.home-page::before {
         background: none;
         border: none;
         color: var(--text-secondary);
-        font-size: 1.75rem; /* Slightly larger for easier tapping */
+        font-size: 2rem; /* Larger for easier tapping */
         cursor: pointer;
-        padding: 0;
+        padding: 0.5rem; /* Increase tappable area */
+        margin: -0.5rem; /* Counteract padding to maintain alignment */
         line-height: 1;
         justify-self: end;
+        align-self: center; /* Ensure vertical centering */
     }
     .close-panel-btn:hover {
         color: var(--text-primary);
@@ -1227,14 +1270,19 @@ body.home-page::before {
 
     /* --- New Mobile Map Interaction Styles --- */
     #mobile-map-container .leaflet-overlay-pane svg path {
-        fill-opacity: 0;
-        stroke-opacity: 0;
-        transition: fill-opacity 0.3s ease, stroke-opacity 0.3s ease;
+        fill-opacity: 0.4;
+        stroke-opacity: 0.9;
+        stroke-width: 2px;
+        stroke: rgba(0, 0, 0, 0.5);
+        transition: fill-opacity 0.3s ease, stroke-opacity 0.3s ease, stroke-width 0.2s ease, stroke 0.2s ease;
     }
 
     #mobile-map-container .leaflet-overlay-pane svg path.highlighted {
         fill-opacity: 0.4;
         stroke-opacity: 0.9;
+        stroke-width: 8px;
+        stroke: var(--accent-gold);
+        animation: pulse 2s infinite;
     }
 
     .map-dim-overlay {

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -47,6 +47,8 @@ function initMobileMap() {
 
     // --- Element References ---
     const mapContainer = document.getElementById('mobile-map-container');
+    const instruction = document.getElementById('mobile-map-instruction');
+    const instructionCloseBtn = instruction.querySelector('button');
     const dimOverlay = mapContainer.querySelector('.map-dim-overlay');
     const infoPanel = document.getElementById('mobile-info-panel');
     const panelHeader = infoPanel.querySelector('.panel-header');
@@ -82,6 +84,7 @@ function initMobileMap() {
         path.setAttribute('stroke-width', '8');
 
         path.addEventListener('click', () => {
+            hideInstruction(); // Hide instruction on first tap
             if (highlightedPath) {
                 highlightedPath.classList.remove('highlighted');
             }
@@ -215,6 +218,17 @@ function initMobileMap() {
             });
         });
     }
+
+    const hideInstruction = () => {
+        if (instruction) {
+            instruction.classList.add('hidden');
+        }
+    };
+
+    instructionCloseBtn.addEventListener('click', (e) => {
+        e.stopPropagation(); // Prevent map click event
+        hideInstruction();
+    });
 
     dimOverlay.addEventListener('click', closePanel);
 


### PR DESCRIPTION
This commit introduces three UX improvements to the mobile view of the interactive map:

1.  **Region Interactivity Cues:**
    - Adds default borders to SVG map regions to make them look like distinct, tappable areas.
    - Implements a more prominent highlight style (thicker, gold border) when a region is selected.
    - Adds a dismissible instructional message that is hidden after the first user interaction.

2.  **Finger-Friendly Close Button:**
    - Increases the font size and padding of the info panel's close button to create a larger, more accessible tap target on mobile devices.

3.  **Highlighted Region Animation:**
    - Adds a subtle pulsing animation to the border of the highlighted map region to draw the user's attention to the selection.