### PR TITLE
This commit implements a final set of enhancements for the mobile map…

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1246,7 +1246,8 @@ body.home-page::before {
         opacity: 0;
     }
 
-    #mobile-map-container .leaflet-overlay-pane svg path {
+    /* Interactive paths are invisible click targets */
+    #mobile-map-container .leaflet-overlay-pane svg > .interactive-region {
         fill: transparent;
         stroke: transparent;
         stroke-width: 0;
@@ -1254,7 +1255,7 @@ body.home-page::before {
     }
 
     /* Add a border and subtle fill to the selected path to show it's active */
-    #mobile-map-container .leaflet-overlay-pane svg path.selected {
+    #mobile-map-container .leaflet-overlay-pane svg > .interactive-region.selected {
         fill: rgba(233, 213, 161, 0.2);
         stroke: var(--accent-gold);
         stroke-width: 8px;

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -107,6 +107,7 @@ function initMobileMap() {
         const path = document.createElementNS("http://www.w3.org/2000/svg", 'path');
         path.setAttribute('d', region.svgPathData);
         path.style.cursor = 'pointer';
+        path.classList.add('interactive-region');
 
         // Add a clone of the path to the mask to make it visible by default
         const maskPath = path.cloneNode();


### PR DESCRIPTION
… view based on user feedback, focusing on an "always-on" discoverability model.

Key changes include:
- The map now loads with a default dimming effect that makes all interactive regions stand out at their normal brightness. This is achieved using a dynamically generated SVG mask that includes all regions.
- When a user taps a region, a distinct border highlight is applied to that region to indicate selection.
- An instructional banner ("Tap a region to explore!") is displayed on first load and fades out after the first interaction.
- The info panel's close button has been enlarged with increased font-size and padding to improve its tap area.